### PR TITLE
Incorrect characters ('*'(shift+8), '~'(tilde)) encoding

### DIFF
--- a/src/main/java/org/scribe/utils/URLUtils.java
+++ b/src/main/java/org/scribe/utils/URLUtils.java
@@ -41,7 +41,9 @@ public class URLUtils
     Preconditions.checkNotNull(string, "Cannot encode null string");
     try
     {
-      return URLEncoder.encode(string, UTF_8).replaceAll("\\+", "%20");
+      return URLEncoder.encode(string, UTF_8).replaceAll("\\+", "%20")
+											 .replaceAll("\\*", "%2A")
+											 .replaceAll("%7E", "~");
     } 
     catch (UnsupportedEncodingException uee)
     {

--- a/src/test/java/org/scribe/extractors/BaseStringExtractorTest.java
+++ b/src/test/java/org/scribe/extractors/BaseStringExtractorTest.java
@@ -23,7 +23,7 @@ public class BaseStringExtractorTest
   @Test
   public void shouldExtractBaseStringFromOAuthRequest()
   {
-    String expected = "GET&http%3A%2F%2Fexample.com&oauth_callback%3Dhttp%253A%252F%252Fexample%252Fcallback%26oauth_consumer_key%3DAS%2523%2524%255E*%2540%2526%26oauth_signature%3DOAuth-Signature%26oauth_timestamp%3D123456";
+    String expected = "GET&http%3A%2F%2Fexample.com&oauth_callback%3Dhttp%253A%252F%252Fexample%252Fcallback%26oauth_consumer_key%3DAS%2523%2524%255E%252A%2540%2526%26oauth_signature%3DOAuth-Signature%26oauth_timestamp%3D123456";
     String baseString = extractor.extract(request);
     assertEquals(expected, baseString);
   }
@@ -45,7 +45,7 @@ public class BaseStringExtractorTest
   @Test
   public void shouldProperlyEncodeSpaces()
   {
-    String expected = "GET&http%3A%2F%2Fexample.com&body%3Dthis%2520param%2520has%2520whitespace%26oauth_callback%3Dhttp%253A%252F%252Fexample%252Fcallback%26oauth_consumer_key%3DAS%2523%2524%255E*%2540%2526%26oauth_signature%3DOAuth-Signature%26oauth_timestamp%3D123456";
+    String expected = "GET&http%3A%2F%2Fexample.com&body%3Dthis%2520param%2520has%2520whitespace%26oauth_callback%3Dhttp%253A%252F%252Fexample%252Fcallback%26oauth_consumer_key%3DAS%2523%2524%255E%252A%2540%2526%26oauth_signature%3DOAuth-Signature%26oauth_timestamp%3D123456";
     request.addBodyParameter("body", "this param has whitespace");
     assertEquals(expected, extractor.extract(request));
   }

--- a/src/test/java/org/scribe/extractors/HeaderExtractorTest.java
+++ b/src/test/java/org/scribe/extractors/HeaderExtractorTest.java
@@ -24,7 +24,7 @@ public class HeaderExtractorTest
   public void shouldExtractStandardHeader()
   {
     String expected = "OAuth oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\", " + "oauth_signature=\"OAuth-Signature\", "
-        + "oauth_consumer_key=\"AS%23%24%5E*%40%26\", " + "oauth_timestamp=\"123456\"";
+        + "oauth_consumer_key=\"AS%23%24%5E%2A%40%26\", " + "oauth_timestamp=\"123456\"";
     String header = extractor.extract(request);
     assertEquals(expected, header);
   }


### PR DESCRIPTION
Hi, 

According to http://tools.ietf.org/html/rfc5849#section-3.6:

Characters in the unreserved character set as defined by
[RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST NOT be encoded. Others MUST be encoded.

Method URLEncoder.encode encode "~"(tilde) to %7E and it's wrong.
This method doesn't encode "*"(shift+8 or 'asterisk' :)).

I've just made small patch to fix this issue.
