### PR TITLE
wrong boolean expression

### DIFF
--- a/src/main/java/org/scribe/model/OAuthRequest.java
+++ b/src/main/java/org/scribe/model/OAuthRequest.java
@@ -41,12 +41,12 @@ public class OAuthRequest extends Request
 
   private String checkKey(String key)
   {
-    if (!key.startsWith(OAUTH_PREFIX) && !key.equals(OAuthConstants.SCOPE))
-    {
-      throw new IllegalArgumentException(String.format("OAuth parameters must either be %s or start with '%s'", OAuthConstants.SCOPE, OAUTH_PREFIX));
-    } else
+    if (key.startsWith(OAUTH_PREFIX) || key.equals(OAuthConstants.SCOPE))
     {
       return key;
+    } else
+    {
+      throw new IllegalArgumentException(String.format("OAuth parameters must either be %s or start with '%s'", OAuthConstants.SCOPE, OAUTH_PREFIX));
     }
   }
 


### PR DESCRIPTION
hi pablo,

there was a wrong boolean expression in OAuthRequest.java:
in checkKey(String key):
  (!key.startsWith(OAUTH_PREFIX) || !key.equals(OAuthConstants.SCOPE)
it returns true for all keys that do not contain "oauth_".

btw, nice library - like it.
