### PR TITLE
Callback encoding

### DIFF
--- a/src/main/java/org/scribe/builder/api/FacebookApi.java
+++ b/src/main/java/org/scribe/builder/api/FacebookApi.java
@@ -2,6 +2,7 @@ package org.scribe.builder.api;
 
 import org.scribe.exceptions.*;
 import org.scribe.model.*;
+import org.scribe.utils.URLUtils;
 
 public class FacebookApi extends DefaultApi20
 {
@@ -11,6 +12,6 @@ public class FacebookApi extends DefaultApi20
   {
     if(OAuthConstants.OUT_OF_BAND.equals(config.getCallback()))
     	throw new OAuthException("Facebook does not support oob authentication.");
-    return String.format(AUTHORIZE_URL, config.getApiKey(), config.getCallback());
+    return String.format(AUTHORIZE_URL, config.getApiKey(), URLUtils.percentEncode(config.getCallback()));
   }
 }


### PR DESCRIPTION
Pablo,

While testing Scribe (Facebook API) I got an error with a callback URL which has query string parameters. When this callback URL is appended to the authorization URL, it's query string is mixed up with the authorize URL query string, leading to wrong behaviour. To solve this we just need to encode the callback url when appending to the authorization URL.

[]s
Diego Silveira
