### PR TITLE
It would be nice if the request/response body did not assume utf-8 strings

### DIFF
--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -86,7 +86,7 @@ class Request
     for (String key : headers.keySet())
       conn.setRequestProperty(key, headers.get(key));
     if (!headers.containsKey(CONTENT_TYPE)) {
-        conn.setRequestProperty(CONTENT_TYPE, "");
+        conn.setRequestProperty(CONTENT_TYPE, "application/x-www-form-urlencoded");
     }
   }
 

--- a/src/main/java/org/scribe/model/Response.java
+++ b/src/main/java/org/scribe/model/Response.java
@@ -13,10 +13,11 @@ import org.scribe.utils.*;
  */
 public class Response
 {
-  private static final String EMPTY = "";
+  private static final byte[] EMPTY = new byte[0];
 
   private int code;
-  private String body;
+  private byte[] body;
+  private String bodyUTF8;
   private InputStream stream;
   private Map<String, String> headers;
 
@@ -35,7 +36,7 @@ public class Response
     }
   }
 
-  private String parseBodyContents()
+  private byte[] parseBodyContents()
   {
     body = StreamUtils.getStreamContents(getStream());
     return body;
@@ -62,6 +63,19 @@ public class Response
    * @return response body
    */
   public String getBody()
+  {
+    if (bodyUTF8 == null) {
+        bodyUTF8 = new String(getBodyAsByteArray());
+    }
+    return bodyUTF8;
+  }
+
+  /**
+   * Obtains the HTTP Response body
+   *
+   * @return response body
+   */
+  public byte[] getBodyAsByteArray()
   {
     return body != null ? body : parseBodyContents();
   }

--- a/src/main/java/org/scribe/utils/StreamUtils.java
+++ b/src/main/java/org/scribe/utils/StreamUtils.java
@@ -12,31 +12,44 @@ public class StreamUtils
   /**
    * Returns the stream contents as an UTF-8 encoded string
    * 
-   * @param is input stream
-   * @return string contents
+   * @param in input stream
+   * @return stream contents
    */
-  public static String getStreamContents(InputStream is)
+  public static byte[] getStreamContents(InputStream in)
   {
-    Preconditions.checkNotNull(is, "Cannot get String from a null object");
+    Preconditions.checkNotNull(in, "Cannot get String from a null object");
+    ByteArrayOutputStream out = null;
     try
     {
-      final char[] buffer = new char[0x10000];
-      StringBuilder out = new StringBuilder();
-      Reader in = new InputStreamReader(is, "UTF-8");
+      final byte[] buffer = new byte[0x10000];
+      out = new ByteArrayOutputStream();
       int read;
-      do
-      {
-        read = in.read(buffer, 0, buffer.length);
-        if (read > 0)
-        {
-          out.append(buffer, 0, read);
-        }
-      } while (read >= 0);
-      in.close();
-      return out.toString();
+      while (0 < (read = in.read(buffer, 0, buffer.length)))
+        out.write(buffer, 0, read);
+      return out.toByteArray();
     } catch (IOException ioe)
     {
       throw new IllegalStateException("Error while reading response body", ioe);
+    } finally {
+      close(in);
+      close(out);
+    }
+  }
+
+  /**
+   * Closes any {@link Closeable} while quashing any exceptions.
+   * @param closeable the {@link Closeable} to close (may be {@code null}).
+   */
+  public static void close(Closeable closeable) {
+    if (closeable != null)
+    {
+      try
+      {
+        closeable.close();
+      } catch (IOException e)
+      {
+        // ignore
+      }
     }
   }
 }

--- a/src/test/java/org/scribe/utils/StreamUtilsTest.java
+++ b/src/test/java/org/scribe/utils/StreamUtilsTest.java
@@ -15,7 +15,7 @@ public class StreamUtilsTest
   {
     String value = "expected";
     InputStream is = new ByteArrayInputStream(value.getBytes());
-    String decoded = StreamUtils.getStreamContents(is);
+    String decoded = new String(StreamUtils.getStreamContents(is));
     assertEquals("expected", decoded);
   }
   


### PR DESCRIPTION
The following hacky change does some work to allow access to the raw bytes as not every byte array can be converted into a valid utf-8 string
