### PR TITLE
OAuth requests not being signed properly.

### DIFF
--- a/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
@@ -36,8 +36,8 @@ public class OAuth10aServiceImpl implements OAuthService
   public Token getRequestToken()
   {
     OAuthRequest request = new OAuthRequest(api.getRequestTokenVerb(), api.getRequestTokenEndpoint());
-    addOAuthParams(request, OAuthConstants.EMPTY_TOKEN);
     request.addOAuthParameter(OAuthConstants.CALLBACK, config.getCallback());
+    addOAuthParams(request, OAuthConstants.EMPTY_TOKEN);
     addOAuthHeader(request);
     Response response = request.send();
     return api.getRequestTokenExtractor().extract(response.getBody());


### PR DESCRIPTION
Oauth 1.0 requests are not being signed properly because a parameter is being added to the request after it's been signed.
