### PR TITLE
Support for SAPO (portuguese web portal)

### DIFF
--- a/src/main/java/org/scribe/builder/api/SapoApi.java
+++ b/src/main/java/org/scribe/builder/api/SapoApi.java
@@ -1,0 +1,37 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.Token;
+import org.scribe.model.Verb;
+
+
+public class SapoApi extends DefaultApi10a {
+
+    private static final String AUTHORIZE_URL = "https://id.sapo.pt/oauth/authorize?oauth_token=%s";
+    private static final String ACCESS_URL = "https://id.sapo.pt/oauth/access_token";
+    private static final String REQUEST_URL ="https://id.sapo.pt/oauth/request_token";
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return ACCESS_URL;
+    }
+
+    @Override
+    public String getRequestTokenEndpoint() {
+        return REQUEST_URL;
+    }
+
+    @Override
+    public String getAuthorizationUrl(Token requestToken) {
+        return String.format(AUTHORIZE_URL, requestToken.getToken());
+    }
+
+    @Override
+    public Verb getRequestTokenVerb() {
+        return Verb.GET;
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.GET;
+    }
+}


### PR DESCRIPTION
Added the API class for SAPO (www.sapo.pt) the biggest Portuguese web portal. 

Note: Must be used with SignatureType.QueryString
