### PR TITLE
Automatically add the content-type header if we are form url encoding the params

### DIFF
--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -244,7 +244,7 @@ class Request
     	body = URLUtils.formURLEncodeMap(bodyParams);
     	//add content-type header
     	if (!this.headers.containsKey(CONTENT_TYPE))
-    		this.addHeader(CONTENT_TYPE, "application/x-www-form-urlencoded");
+    		this.addHeader(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=" + getCharset() + ";");
     }
     try
     {


### PR DESCRIPTION
Automatically add the content-type header if we are form url encoding the params.  This pull request contains the charset in the header.
