### PR TITLE
Support for Google's OAuth2

### DIFF
--- a/src/main/java/org/scribe/builder/api/Google2Api.java
+++ b/src/main/java/org/scribe/builder/api/Google2Api.java
@@ -1,0 +1,30 @@
+package org.scribe.builder.api;
+
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.model.*;
+
+public class Google2Api extends DefaultApi20 {
+
+    private static final String AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/auth?client_id=%s&redirect_uri=%s&scope=%s&response_type=code";
+
+    @Override
+    public String getAuthorizationUrl(OAuthConfig config) {
+        return String.format(AUTHORIZATION_URL, config.getApiKey(), config.getCallback(), config.getScope());
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return "https://accounts.google.com/o/oauth2/token";
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.POST;
+    }
+
+    @Override
+    public AccessTokenExtractor getAccessTokenExtractor() {
+        return new JsonTokenExtractor();
+    }
+}

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -34,10 +34,13 @@ public class OAuthConstants
   public static final String TOKEN = "oauth_token";
   public static final String TOKEN_SECRET = "oauth_token_secret";
   public static final String OUT_OF_BAND = "oob";
+  public static final String GOOGLE_OUT_OF_BAND = "urn:ietf:wg:oauth:2.0:oob";
   public static final String VERIFIER = "oauth_verifier";
   public static final String HEADER = "Authorization";
   public static final Token EMPTY_TOKEN = new Token("", "");
   public static final String SCOPE = "scope";
+  public static final String GRANT_TYPE = "grant_type";
+  public static final String AUTHORIZATION_CODE = "authorization_code";
 
   //OAuth 2.0
   public static final String ACCESS_TOKEN = "access_token";

--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -154,6 +154,24 @@ class Request
   }
 
   /**
+   * Add a parameter : as body parameter for POST & PUT request, as query string parameter for GET & DELETE request.
+   * 
+   * @param key the parameter name
+   * @param value the parameter value
+   */
+  public void addParameter(String key, String value)
+  {
+      switch (this.verb) {
+          case POST: case PUT:
+              addBodyParameter(key, value);
+              break;
+          default:
+              addQuerystringParameter(key, value);
+              break;
+      }
+  }
+  
+  /**
    * Add body payload.
    * 
    * This method is used when the HTTP body is not a form-url-encoded string,

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -28,10 +28,12 @@ public class OAuth20ServiceImpl implements OAuthService
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
     OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-    request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
-    request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+    request.addParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+    request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+    request.addParameter(OAuthConstants.CODE, verifier.getValue());
+    request.addParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+    // Google required OAuth2 parameter
+    request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
     if(config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
     Response response = request.send();
     return api.getAccessTokenExtractor().extract(response.getBody());

--- a/src/main/java/org/scribe/utils/Preconditions.java
+++ b/src/main/java/org/scribe/utils/Preconditions.java
@@ -61,7 +61,7 @@ public class Preconditions
   public static void checkValidOAuthCallback(String url, String errorMsg)
   {
     checkEmptyString(url, errorMsg);
-    if(url.toLowerCase().compareToIgnoreCase(OAuthConstants.OUT_OF_BAND) != 0)
+    if(url.compareToIgnoreCase(OAuthConstants.OUT_OF_BAND) != 0 && url.compareToIgnoreCase(OAuthConstants.GOOGLE_OUT_OF_BAND) != 0)
     {
       check(isUrl(url), errorMsg);  
     }

--- a/src/test/java/org/scribe/examples/Google2Example.java
+++ b/src/test/java/org/scribe/examples/Google2Example.java
@@ -1,0 +1,68 @@
+package org.scribe.examples;
+
+import java.util.*;
+
+import org.scribe.builder.*;
+import org.scribe.builder.api.*;
+import org.scribe.model.*;
+import org.scribe.oauth.*;
+
+public class Google2Example
+{
+  private static final String NETWORK_NAME = "Google (OAuth 2)";
+  private static final String PROTECTED_RESOURCE_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
+  private static final Token EMPTY_TOKEN = null;
+
+  public static void main(String[] args)
+  {
+    // Replace these with your own api key, api secret, and redirect URI
+    String apiKey = "your_api_id";
+    String apiSecret = "your_api_secret";
+    // String redirect_uri = "urn:ietf:wg:oauth:2.0:oob";   // Special value for OOB
+    String redirect_uri = "your_registered_callback_uri";
+    
+    OAuthService service = new ServiceBuilder()
+                                  .provider(Google2Api.class)
+                                  .apiKey(apiKey)
+                                  .apiSecret(apiSecret)
+                                  .callback(redirect_uri)
+                                  .scope("https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email")
+                                  .build();
+    Scanner in = new Scanner(System.in);
+
+    System.out.println("=== " + NETWORK_NAME + "'s OAuth Workflow ===");
+    System.out.println();
+
+    // Obtain the Authorization URL
+    System.out.println("Fetching the Authorization URL...");
+    String authorizationUrl = service.getAuthorizationUrl(EMPTY_TOKEN);
+    System.out.println("Got the Authorization URL!");
+    System.out.println("Now go and authorize Scribe here:");
+    System.out.println(authorizationUrl);
+    System.out.println("And paste the authorization code here");
+    System.out.print(">>");
+    Verifier verifier = new Verifier(in.nextLine());
+    System.out.println();
+    
+    // Trade the Request Token and Verfier for the Access Token
+    System.out.println("Trading the Request Token for an Access Token...");
+    Token accessToken = service.getAccessToken(EMPTY_TOKEN, verifier);
+    System.out.println("Got the Access Token!");
+    System.out.println("(if your curious it looks like this: " + accessToken + " )");
+    System.out.println();
+
+    // Now let's go and ask for a protected resource!
+    System.out.println("Now we're going to access a protected resource...");
+    OAuthRequest request = new OAuthRequest(Verb.GET, PROTECTED_RESOURCE_URL);
+    service.signRequest(accessToken, request);
+    Response response = request.send();
+    System.out.println("Got it! Lets see what we found...");
+    System.out.println();
+    System.out.println(response.getCode());
+    System.out.println(response.getBody());
+
+    System.out.println();
+    System.out.println("Thats it man! Go and build something awesome with Scribe! :)");
+
+  }
+}

--- a/src/test/java/org/scribe/model/RequestTest.java
+++ b/src/test/java/org/scribe/model/RequestTest.java
@@ -75,6 +75,25 @@ public class RequestTest
   }
 
   @Test
+  public void shouldAllowAddingParametersAfterCreationForGET()
+  {
+    Request request = new Request(Verb.GET, "http://example.com?one=val");
+    request.addParameter("two", "other val");
+    request.addParameter("more", "params");
+    assertEquals(3, request.getQueryStringParams().size());
+  }
+
+  @Test
+  public void shouldAllowAddingParametersAfterCreationForPOST()
+  {
+    assertEquals("param=value&param+with+spaces=value+with+spaces", postRequest.getBodyContents());
+    postRequest.addParameter("two", "other");
+    postRequest.addParameter("other param with spaces", "other value with spaces");
+    assertTrue(postRequest.getBodyContents().contains("two=other"));
+    assertTrue(postRequest.getBodyContents().contains("other+param+with+spaces=other+value+with+spaces"));
+  }
+
+  @Test
   public void shouldHandleQueryStringSpaceEncodingProperly()
   {
     assertTrue(getRequest.getQueryStringParams().get("other param").equals("value with spaces"));


### PR DESCRIPTION
- new Google2Api
- added Request#addParameter() to support adding parameter on GET or POST request in regards to the request's verb (Google is expecting a POST for requesting access token)
- new Google2Example.

Hacked thanks to tbruyelle on https://github.com/fernandezpablo85/scribe-java/issues/117
