### PR TITLE
Enhance ServiceBuilder to accept properties resource containing oauth properties

### DIFF
--- a/src/main/java/org/scribe/builder/ServiceBuilder.java
+++ b/src/main/java/org/scribe/builder/ServiceBuilder.java
@@ -76,6 +76,31 @@ public class ServiceBuilder
 	  return this;
   }
 
+/** Configures the oauth properties
+   * 
+   * @param propertyResource name of the propertyResource
+   * @return the {@link ServiceBuilder} instance for method chaining
+   */
+  public ServiceBuilder propertiesResource(String propertyResource) throws IOException 
+  {
+	Properties properties = new Properties();
+    properties.load(ServiceBuilder.class.getClassLoader().getResourceAsStream(propertyResource));
+    return properties(properties);
+  }
+
+  /** Configures the oauth properties
+   * 
+   * @param property oauth properties
+   * @return the {@link ServiceBuilder} instance for method chaining
+   */
+  public ServiceBuilder properties(Properties properties) 
+  {
+	return apiKey(properties.getProperty(OAuthConstants.CLIENT_ID))
+		.apiSecret(properties.getProperty(OAuthConstants.CLIENT_SECRET))
+        .callback(properties.getProperty(OAuthConstants.CALLBACK))
+        .scope(properties.getProperty(OAuthConstants.SCOPE));
+  }
+
   /**
    * Adds an OAuth callback url
    * 


### PR DESCRIPTION
Currently all the keys like apiKey, secretKey, etc are hard coded.
I have enhanced the ServiceBuilder class to accept the properties object / property resource name.
All the oauth properties can be declared in the property file.

apiKey = api_key
apiSecret = secret_key
oauth_callback = callback_url
scope = https://www.google.com/m8/feeds/
tokenUrl = https://accounts.google.com/o/oauth2/token

Filed issue here: https://github.com/fernandezpablo85/scribe-java/issues/223

Using this change, we can create OAuthService using properties resource name
OAuthService oAuthService = new ServiceBuilder().provider(GoogleApi20.class)
                .propertiesResource("oauth_google.properties")
                .build();
