### PR TITLE
Query string params are not rfc3986

### DIFF
--- a/src/main/java/org/scribe/model/ParameterList.java
+++ b/src/main/java/org/scribe/model/ParameterList.java
@@ -1,7 +1,5 @@
 package org.scribe.model;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -63,14 +61,7 @@ public class ParameterList
 
   public String asOauthBaseString()
   {
-    try
-    {
-      return URLEncoder.encode(asFormUrlEncodedString(), "UTF8");
-    }
-    catch (UnsupportedEncodingException uee)
-    {
-     throw new RuntimeException();
-    }
+    return OAuthEncoder.encode(asFormUrlEncodedString());
   }
 
   public String asFormUrlEncodedString()


### PR DESCRIPTION
Query string parameters are being encoded into x-www-form-urlencoded format, however OAuth spec requires rfc3986. This creates an invalid signature, which causes the request to fail.

Also, would you mind rolling this into a 1.3.1 release?
