### PR TITLE
remove @Override tag in JsonTokenExtractor.java file

### DIFF
--- a/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
+++ b/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
@@ -10,7 +10,6 @@ public class JsonTokenExtractor implements AccessTokenExtractor
 {
   private Pattern accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
 
-  @Override
   public Token extract(String response)
   {
     Preconditions.checkEmptyString(response, "Cannot extract a token from a null or empty String");


### PR DESCRIPTION
Because of @Override tag in JsonTokenExtractor.java file, in JDK1.5, this file cann't compile correctly. So I remove it.
