### PR TITLE
removed auth keys & secret keys from examples

### DIFF
--- a/src/test/java/org/scribe/examples/Foursquare2Example.java
+++ b/src/test/java/org/scribe/examples/Foursquare2Example.java
@@ -15,8 +15,8 @@ public class Foursquare2Example
   public static void main(String[] args)
   {
     // Replace these with your own api key and secret
-    String apiKey = "FEGFXJUFANVVDHVSNUAMUKTTXCP1AJQD53E33XKJ44YP1S4I";
-    String apiSecret = "AYWKUL5SWPNC0CTQ202QXRUG2NLZYXMRA34ZSDW4AUYBG2RC";
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
                                   .provider(Foursquare2Api.class)
                                   .apiKey(apiKey)

--- a/src/test/java/org/scribe/examples/FoursquareExample.java
+++ b/src/test/java/org/scribe/examples/FoursquareExample.java
@@ -13,10 +13,13 @@ public class FoursquareExample
   
   public static void main(String[] args)
   {
+    // Replace these with your own api key and secret
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
                                 .provider(FoursquareApi.class)
-                                .apiKey("FEGFXJUFANVVDHVSNUAMUKTTXCP1AJQD53E33XKJ44YP1S4I")
-                                .apiSecret("AYWKUL5SWPNC0CTQ202QXRUG2NLZYXMRA34ZSDW4AUYBG2RC")
+                                .apiKey(apiKey)
+                                .apiSecret(apiSecret)
                                 .build();
     Scanner in = new Scanner(System.in);
 

--- a/src/test/java/org/scribe/examples/LinkedInExample.java
+++ b/src/test/java/org/scribe/examples/LinkedInExample.java
@@ -13,10 +13,13 @@ public class LinkedInExample
   
   public static void main(String[] args)
   {
+    // Replace these with your own api key and secret
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
                                 .provider(LinkedInApi.class)
-                                .apiKey("CiEgwWDkA5BFpNrc0RfGyVuSlOh4tig5kOTZ9q97qcXNrFl7zqk-Ts7DqRGaKDCV")
-                                .apiSecret("dhho4dfoCmiQXrkw4yslork5XWLFnPSuMR-8gscPVjY4jqFFHPYWJKgpFl4uLTM6")
+                                .apiKey(apiKey)
+                                .apiSecret(apiSecret)
                                 .build();
     Scanner in = new Scanner(System.in);
     

--- a/src/test/java/org/scribe/examples/MeetupExample.java
+++ b/src/test/java/org/scribe/examples/MeetupExample.java
@@ -17,10 +17,13 @@ public class MeetupExample
 
 	  public static void main(String[] args)
 	  {
+	    // Replace these with your own api key and secret
+	    String apiKey = "your_app_id";
+	    String apiSecret = "your_api_secret";
 	    OAuthService service = new ServiceBuilder()
 	                                .provider(MeetupApi.class)
-	                                .apiKey("j1khkp0dus323ftve0sdcv6ffe")
-	                                .apiSecret("6s6gt6q59gvfjtsvgcmht62gq4")
+	                                .apiKey(apiKey)
+	                                .apiSecret(apiSecret)
 	                                .build();
 	    Scanner in = new Scanner(System.in);
 

--- a/src/test/java/org/scribe/examples/SinaWeibo2Example.java
+++ b/src/test/java/org/scribe/examples/SinaWeibo2Example.java
@@ -15,8 +15,8 @@ public class SinaWeibo2Example
   public static void main(String[] args)
   {
     // Replace these with your own api key and secret
-    String apiKey = "342348223";
-    String apiSecret = "cfdf672e166a4bc954c0e33f03cf0d1b";
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
         .provider(SinaWeiboApi20.class)
         .apiKey(apiKey)

--- a/src/test/java/org/scribe/examples/TwitterExample.java
+++ b/src/test/java/org/scribe/examples/TwitterExample.java
@@ -13,10 +13,13 @@ public class TwitterExample
   
   public static void main(String[] args)
   {
+    // Replace these with your own api key and secret
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
                                 .provider(TwitterApi.class)
-                                .apiKey("6icbcAXyZx67r8uTAUM5Qw")
-                                .apiSecret("SCCAdUUc6LXxiazxH3N0QfpNUvlUy84mZ2XZKiv39s")
+                                .apiKey(apiKey)
+                                .apiSecret(apiSecret)
                                 .build();
     Scanner in = new Scanner(System.in);
 

--- a/src/test/java/org/scribe/examples/YahooExample.java
+++ b/src/test/java/org/scribe/examples/YahooExample.java
@@ -13,10 +13,13 @@ public class YahooExample
 
   public static void main(String[] args)
   {
+    // Replace these with your own api key and secret
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
     OAuthService service = new ServiceBuilder()
                                 .provider(YahooApi.class)
-                                .apiKey("dj0yJmk9TXZDWVpNVVdGaVFmJmQ9WVdrOWMweHZXbkZLTkhVbWNHbzlNVEl5TWprd05qUTJNZy0tJnM9Y29uc3VtZXJzZWNyZXQmeD0wMw--")
-                                .apiSecret("262be559f92a2be20c4c039419018f2b48cdfce9")
+                                .apiKey(apiKey)
+                                .apiSecret(apiSecret)
                                 .build();
     Scanner in = new Scanner(System.in);
 


### PR DESCRIPTION
Hi,

I noticed there were some app IDs and secret keys in some examples, while other examples told the user to replace them. fixed this so it's "you should replace this" in all of them.
