### PR TITLE
Implement OAuth 2.0 refresh access token

### DIFF
--- a/src/main/java/org/scribe/builder/api/DefaultApi20.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi20.java
@@ -67,4 +67,11 @@ public abstract class DefaultApi20 implements Api
     return new OAuth20ServiceImpl(this, config);
   }
 
+  /**
+   * @return the parameter needed to refresh a access token.
+   */
+  public String getRefreshTokenParameterName()
+  {
+    throw new UnsupportedOperationException("Refresh token is not implemented for "+getClass().getSimpleName());
+  }
 }

--- a/src/main/java/org/scribe/builder/api/FacebookApi.java
+++ b/src/main/java/org/scribe/builder/api/FacebookApi.java
@@ -30,4 +30,10 @@ public class FacebookApi extends DefaultApi20
       return String.format(AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
     }
   }
+
+  @Override
+  public String getRefreshTokenParameterName()
+  {
+    return "fb_exchange_token";
+  }
 }

--- a/src/main/java/org/scribe/builder/api/LiveApi.java
+++ b/src/main/java/org/scribe/builder/api/LiveApi.java
@@ -37,4 +37,10 @@ public class LiveApi extends DefaultApi20
 	{
 		return new JsonTokenExtractor();
 	}
+
+  @Override
+  public String getRefreshTokenParameterName()
+  {
+    return "refresh_token";
+  }
 }

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -45,5 +45,6 @@ public class OAuthConstants
   public static final String CLIENT_SECRET = "client_secret";
   public static final String REDIRECT_URI = "redirect_uri";
   public static final String CODE = "code";
+  public static final String GRANT_TYPE = "grant_type";
   
 }

--- a/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
@@ -85,6 +85,14 @@ public class OAuth10aServiceImpl implements OAuthService
   /**
    * {@inheritDoc}
    */
+  public Token refreshAccessToken(Token accessToken)
+  {
+    throw new UnsupportedOperationException("Refresh token is not supported in Scribe OAuth 1.0");
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public void signRequest(Token token, OAuthRequest request)
   {
     config.log("signing request: " + request.getCompleteUrl());

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -40,6 +40,28 @@ public class OAuth20ServiceImpl implements OAuthService
   /**
    * {@inheritDoc}
    */
+  public Token refreshAccessToken(Token accessToken)
+  {
+
+    String accessTokenEndpoint = api.getAccessTokenEndpoint();
+    if (accessTokenEndpoint.contains("?grant_type="))
+    {
+      // handle the ugly case where the grant_type parameter is already hardcoded in the constant url
+      accessTokenEndpoint = accessTokenEndpoint.substring(0, accessTokenEndpoint.indexOf("?"));
+    }
+    OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), accessTokenEndpoint);
+    request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+    request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+    request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+    request.addQuerystringParameter(OAuthConstants.GRANT_TYPE, api.getRefreshTokenParameterName());
+    request.addQuerystringParameter(api.getRefreshTokenParameterName(), accessToken.getToken());
+    Response response = request.send();
+    return api.getAccessTokenExtractor().extract(response.getBody());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public Token getRequestToken()
   {
     throw new UnsupportedOperationException("Unsupported operation, please use 'getAuthorizationUrl' and redirect your users there");

--- a/src/main/java/org/scribe/oauth/OAuthService.java
+++ b/src/main/java/org/scribe/oauth/OAuthService.java
@@ -28,6 +28,19 @@ public interface OAuthService
   public Token getAccessToken(Token requestToken, Verifier verifier);
 
   /**
+   * Refresh the access token to extend its expiration date.
+   * <p/>
+   * For the token in parameter, Facebook needs the access_token, while Live
+   * needs the refresh_token (which can be found only in the 
+   * {@link org.scribe.model.Token#getRawResponse()} returned by 
+   * {@link #getAccessToken(org.scribe.model.Token, org.scribe.model.Verifier)})
+   *
+   * @param accessToken access or refresh token, depending on the OAuth provider 
+   * @return fresh access token
+   */
+  public Token refreshAccessToken(Token accessToken);
+
+  /**
    * Signs am OAuth request
    * 
    * @param accessToken access token (obtained previously)


### PR DESCRIPTION
Some OAuth providers ask to extend the access token expiration date, in
order to continue using it.
Microsoft Live do that, and it will be soon mandatory for Facebook
because they will deprecate the 'offline_access' permission.

To refresh an access token, you need to access the accessTokenEndPoint
with other parameters like a specific 'grant_type' parameter.
