### PR TITLE
Support the Evernote API

### DIFF
--- a/src/main/java/org/scribe/builder/api/EvernoteApi.java
+++ b/src/main/java/org/scribe/builder/api/EvernoteApi.java
@@ -1,39 +1,27 @@
 package org.scribe.builder.api;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.scribe.exceptions.OAuthException;
-import org.scribe.extractors.AccessTokenExtractor;
 import org.scribe.model.Token;
-import org.scribe.utils.OAuthEncoder;
-import org.scribe.utils.Preconditions;
 
 public class EvernoteApi extends DefaultApi10a
 {
-  private static final String EVERNOTE_URL = "https://www.evernote.com";
-  
-	@Override
+  private static final String AUTHORIZATION_URL = "https://www.evernote.com/OAuth.action?oauth_token=%s";
+
+  @Override
 	public String getRequestTokenEndpoint()
   {
-		return EVERNOTE_URL + "/oauth";
-	}
+    return "https://www.evernote.com/oauth";
+  }
 
 	@Override
 	public String getAccessTokenEndpoint()
 	{
-		return EVERNOTE_URL + "/oauth";
+	  return "https://www.evernote.com/oauth";
 	}
 	
 	@Override
 	public String getAuthorizationUrl(Token requestToken)
 	{
-	  return String.format(EVERNOTE_URL + "/OAuth.action?oauth_token=%s", requestToken.getToken());
-	}
-	
-	@Override
-	public AccessTokenExtractor getAccessTokenExtractor() {
-	  return new EvernoteAccessTokenExtractor();
+	  return String.format(AUTHORIZATION_URL, requestToken.getToken());
 	}
 
 	public static class Sandbox extends EvernoteApi
@@ -57,37 +45,5 @@ public class EvernoteApi extends DefaultApi10a
 	  {
 	    return String.format(SANDBOX_URL + "/OAuth.action?oauth_token=%s", requestToken.getToken());
 	  }
-	}
-
-	public static class EvernoteAccessTokenExtractor implements AccessTokenExtractor {
-	  
-	  private static final Pattern TOKEN_REGEX = Pattern.compile("oauth_token=([^&]+)");
-	  // Evernote access tokens include an empty token secret (the empty string).
-	  private static final Pattern SECRET_REGEX = Pattern.compile("oauth_token_secret=([^&]*)");
-	  
-	  /**
-	   * {@inheritDoc} 
-	   */
-	  public Token extract(String response)
-	  {
-	    Preconditions.checkEmptyString(response, "Response body is incorrect. " +
-	        "Can't extract a token from an empty string");
-	    return new Token(extract(response, TOKEN_REGEX), extract(response, SECRET_REGEX), response);
-	  }
-	  
-	  private String extract(String response, Pattern p)
-	  {
-	    Matcher matcher = p.matcher(response);
-	    if (matcher.find() && matcher.groupCount() >= 1)
-	    {
-	      return OAuthEncoder.decode(matcher.group(1));
-	    }
-	    else
-	    {
-	      throw new OAuthException("Response body is incorrect. " +
-	          "Can't extract token and secret from this: '" + response + "'", null);
-	    }
-	  }
-	}
-	
+	}	
 }

--- a/src/main/java/org/scribe/extractors/TokenExtractorImpl.java
+++ b/src/main/java/org/scribe/extractors/TokenExtractorImpl.java
@@ -16,7 +16,7 @@ import org.scribe.utils.*;
 public class TokenExtractorImpl implements RequestTokenExtractor, AccessTokenExtractor
 {
   private static final Pattern TOKEN_REGEX = Pattern.compile("oauth_token=([^&]+)");
-  private static final Pattern SECRET_REGEX = Pattern.compile("oauth_token_secret=([^&]+)");
+  private static final Pattern SECRET_REGEX = Pattern.compile("oauth_token_secret=([^&]*)");
 
   /**
    * {@inheritDoc} 

--- a/src/test/java/org/scribe/extractors/TokenExtractorTest.java
+++ b/src/test/java/org/scribe/extractors/TokenExtractorTest.java
@@ -43,6 +43,15 @@ public class TokenExtractorTest
     assertEquals("hh5s93j4hdidpola", extracted.getToken());
     assertEquals("hdhd0244k9j7ao03", extracted.getSecret());
   }
+  
+  @Test
+  public void shouldExtractTokenWithEmptySecret() 
+  {
+    String response = "oauth_token=hh5s93j4hdidpola&oauth_token_secret=";
+    Token extracted = extractor.extract(response);
+    assertEquals("hh5s93j4hdidpola", extracted.getToken());
+    assertEquals("", extracted.getSecret());
+  }
 
   @Test(expected = OAuthException.class)
   public void shouldThrowExceptionIfTokenIsAbsent()


### PR DESCRIPTION
This pull request updates Scribe to support the Evernote API. Specifically:

1) Accept empty oauth_token_secret values in access token responses. Evernote doesn't use the oauth_token_secret because OAuth isn't used to make authenticated requests. Instead, the oauth_token value is passed directly via Evernote API methods. A unit test method was added to verify this change.

2) The Evernote OAuth provider now supports both GET and POST requests, so there is no need to override the get*Verb methods.

3) Fix incorrect URLs in the EvernoteApi.Sandbox class.
