### PR TITLE
Add WordPress support

### DIFF
--- a/src/main/java/org/scribe/builder/api/DefaultApi20.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi20.java
@@ -44,6 +44,26 @@ public abstract class DefaultApi20 implements Api
   }
 	
   /**
+   * Returns the verb for the access token parameters (defaults to GET)
+   * 
+   * @return access token endpoint verb
+   */
+  public Verb getAccessTokenParametersVerb()
+  {
+    return Verb.GET;
+  }
+
+  /**
+   * Returns if the grant_type parameter must be set (defaults to false)
+   * 
+   * @return if the grant_type parameter must be set
+   */
+  public boolean isGrantTypeRequired()
+  {
+    return false;
+  }
+
+  /**
    * Returns the URL that receives the access token requests.
    * 
    * @return access token URL

--- a/src/main/java/org/scribe/builder/api/WordPressApi.java
+++ b/src/main/java/org/scribe/builder/api/WordPressApi.java
@@ -1,0 +1,53 @@
+package org.scribe.builder.api;
+
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.Verb;
+import org.scribe.utils.OAuthEncoder;
+import org.scribe.utils.Preconditions;
+
+public final class WordPressApi extends DefaultApi20
+{
+  private static final String BASE_URL = "https://public-api.wordpress.com/oauth2/";
+
+  private static final String AUTHORIZE_URL = BASE_URL + "authorize?client_id=%s&redirect_uri=%s&response_type=code";
+
+  @Override
+  public String getAccessTokenEndpoint()
+  {
+    return BASE_URL + "token";
+  }
+
+  @Override
+  public String getAuthorizationUrl(OAuthConfig config)
+  {
+    Preconditions.checkValidUrl(config.getCallback(), "Must provide a valid url as callback. WordPress does not support OOB");
+
+    return String.format(AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
+  }
+
+  @Override
+  public Verb getAccessTokenVerb()
+  {
+    return Verb.POST;
+  }
+
+  @Override
+  public Verb getAccessTokenParametersVerb()
+  {
+    return Verb.POST;
+  }
+
+  @Override
+  public boolean isGrantTypeRequired()
+  {
+    return true;
+  }
+
+  @Override
+  public AccessTokenExtractor getAccessTokenExtractor()
+  {
+    return new JsonTokenExtractor();
+  }
+}

--- a/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
+++ b/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
@@ -10,7 +10,6 @@ public class JsonTokenExtractor implements AccessTokenExtractor
 {
   private Pattern accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
 
-  @Override
   public Token extract(String response)
   {
     Preconditions.checkEmptyString(response, "Cannot extract a token from a null or empty String");

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -45,5 +45,7 @@ public class OAuthConstants
   public static final String CLIENT_SECRET = "client_secret";
   public static final String REDIRECT_URI = "redirect_uri";
   public static final String CODE = "code";
-  
+  public static final String GRANT_TYPE = "grant_type";
+  public static final String AUTHORIZATION_CODE = "authorization_code";
+
 }

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -28,11 +28,24 @@ public class OAuth20ServiceImpl implements OAuthService
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
     OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-    request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
-    request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
-    if(config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
+    if (api.getAccessTokenParametersVerb() == Verb.GET)
+    {
+      request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+      request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
+      request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+      if (config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
+      if (api.isGrantTypeRequired()) request.addQuerystringParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
+    }
+    else
+    {
+      request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+      request.addBodyParameter(OAuthConstants.CODE, verifier.getValue());
+      request.addBodyParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+      if (config.hasScope()) request.addBodyParameter(OAuthConstants.SCOPE, config.getScope());
+      if (api.isGrantTypeRequired()) request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
+    }
     Response response = request.send();
     return api.getAccessTokenExtractor().extract(response.getBody());
   }

--- a/src/test/java/org/scribe/examples/WordPressExample.java
+++ b/src/test/java/org/scribe/examples/WordPressExample.java
@@ -1,0 +1,65 @@
+package org.scribe.examples;
+
+import org.scribe.builder.ServiceBuilder;
+import org.scribe.builder.api.WordPressApi;
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Response;
+import org.scribe.model.Token;
+import org.scribe.model.Verb;
+import org.scribe.model.Verifier;
+import org.scribe.oauth.OAuthService;
+
+import java.util.Scanner;
+
+public class WordPressExample
+{
+  private static final String NETWORK_NAME = "WordPress";
+
+  private static final String PROTECTED_RESOURCE_URL = "https://public-api.wordpress.com/rest/v1/me/?pretty=1";
+
+  private static final Token EMPTY_TOKEN = null;
+
+  public static void main(String[] args)
+  {
+    // Replace these with your own api key and secret
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
+    OAuthService service = new ServiceBuilder().provider(WordPressApi.class).apiKey(apiKey).apiSecret(apiSecret).callback("http://www.google.com/").build();
+    Scanner in = new Scanner(System.in);
+
+    System.out.println("=== " + NETWORK_NAME + "'s OAuth Workflow ===");
+    System.out.println();
+
+    // Obtain the Authorization URL
+    System.out.println("Fetching the Authorization URL...");
+    String authorizationUrl = service.getAuthorizationUrl(EMPTY_TOKEN);
+    System.out.println("Got the Authorization URL!");
+    System.out.println("Now go and authorize Scribe here:");
+    System.out.println(authorizationUrl);
+    System.out.println("And paste the authorization code here");
+    System.out.print(">>");
+    Verifier verifier = new Verifier(in.nextLine());
+    System.out.println();
+
+    // Trade the Request Token and Verfier for the Access Token
+    System.out.println("Trading the Request Token for an Access Token...");
+    Token accessToken = service.getAccessToken(EMPTY_TOKEN, verifier);
+    System.out.println("Got the Access Token!");
+    System.out.println("(if your curious it looks like this: " + accessToken + " )");
+    System.out.println();
+
+    // Now let's go and ask for a protected resource!
+    System.out.println("Now we're going to access a protected resource...");
+    OAuthRequest request = new OAuthRequest(Verb.GET, PROTECTED_RESOURCE_URL);
+    request.addHeader("Authorization", "Bearer " + accessToken.getToken());
+    Response response = request.send();
+    System.out.println("Got it! Lets see what we found...");
+    System.out.println();
+    System.out.println(response.getCode());
+    System.out.println(response.getBody());
+
+    System.out.println();
+    System.out.println("Thats it man! Go and build something awesome with Scribe! :)");
+
+  }
+}


### PR DESCRIPTION
Hi Pablo,

I try to add WordPress support, but I encounter some problems to make it work with default OAuth20ServiceImpl and DefaultApi20 classes.
So I choose to make a major change in the getAccessToken method to handle more cases and I add customizable "options" in DefaultApi20 : getAccessTokenParametersVerb and isGrantTypeRequired. Their default values make everything backward compatible.

I was also expected the GitHub support to be merged in Scribe, but I saw that the pull request #144 has been closed and you talked about some OAuth 2.0 refactoring I haven't seen in the code yet.
For GitHub support, I can follow the same idea : a new "option" in DefaultApi20 with a default value that makes everything backward compatible (For example, a isCallbackUrlRequiredWhenOOB method with returns true by default) and a specific behaviour in OAuth20ServiceImpl to handle this "option" (add callback url if isCallbackUrlRequiredWhenOOB returns true).

Just let me know if you think I'm in right direction : if it's the case, I could add the GitHub support the same way...

Thanks.
Best regards,
Jérôme
