### PR TITLE
LinkedIn authorize URL changed

### DIFF
--- a/src/main/java/org/scribe/builder/api/LinkedInApi.java
+++ b/src/main/java/org/scribe/builder/api/LinkedInApi.java
@@ -4,7 +4,7 @@ import org.scribe.model.*;
 
 public class LinkedInApi extends DefaultApi10a
 {
-  private static final String AUTHORIZE_URL = "https://api.linkedin.com/uas/oauth/authorize?oauth_token=%s";
+  private static final String AUTHORIZE_URL = "https://api.linkedin.com/uas/oauth/authenticate?oauth_token=%s";
 
   @Override
   public String getAccessTokenEndpoint()


### PR DESCRIPTION
I've changed the URL, because this is the one mentioned in [LinkedIn docs](https://developer.linkedin.com/documents/authentication).

From the functional perspective, we should use this one because otherwise a user will be asked each time to pass/confirm his credentials, even if he's already authenticated on LinkedIn. Because of that 'one-click authentication' doesn't work.
