### PR TITLE
Add support for Ubutun One

### DIFF
--- a/src/main/java/org/scribe/builder/api/UbuntuOneApi.java
+++ b/src/main/java/org/scribe/builder/api/UbuntuOneApi.java
@@ -1,0 +1,40 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.Token;
+import org.scribe.services.*;
+
+/**
+ * @author Julio Gutierrez
+ * 
+ *         Sep 6, 2012
+ */
+public class UbuntuOneApi extends DefaultApi10a
+{
+
+  private static final String AUTHORIZATION_URL = "https://one.ubuntu.com/oauth/authorize/?oauth_token=%s";
+
+  @Override
+  public String getAccessTokenEndpoint()
+  {
+    return "https://one.ubuntu.com/oauth/access/";
+  }
+
+  @Override
+  public String getAuthorizationUrl(Token requestToken)
+  {
+    return String.format(AUTHORIZATION_URL, requestToken.getToken());
+  }
+
+  @Override
+  public String getRequestTokenEndpoint()
+  {
+    return "https://one.ubuntu.com/oauth/request/";
+  }
+
+  @Override
+  public SignatureService getSignatureService()
+  {
+    return new PlaintextSignatureService();
+  }
+
+}

--- a/src/main/java/org/scribe/services/PlaintextSignatureService.java
+++ b/src/main/java/org/scribe/services/PlaintextSignatureService.java
@@ -11,7 +11,7 @@ import org.scribe.utils.*;
  */
 public class PlaintextSignatureService implements SignatureService
 {
-  private static final String METHOD = "plaintext";
+  private static final String METHOD = "PLAINTEXT";
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
Yammer Api (which is the other api using the plaintext signature) is not affected by this change, i double checked it
