### PR TITLE
Add support for HEAD, OPTIONS, TRACE and PATCH

### DIFF
--- a/src/main/java/org/scribe/model/Verb.java
+++ b/src/main/java/org/scribe/model/Verb.java
@@ -7,5 +7,5 @@ package org.scribe.model;
  */
 public enum Verb
 {
-  GET, POST, PUT, DELETE
+  GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH
 }


### PR DESCRIPTION
Expand the available HTTP verbs to include `HEAD`, `OPTIONS`, `TRACE` and `PATCH`.

I need a signed `HEAD` request so I need this verb. I thought I'd add the rest whilst I was there.
