### PR TITLE
Handle proxy and set keep-alive to request instead of JVM

### DIFF
--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -78,7 +78,7 @@ class Request
       {
         connection.setRequestProperty("Connection", "keep-alive");
       }
-      if (proxyHost != null)
+      if (proxyHost != null && proxyHost.length() > 0)
       {
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
         connection = (HttpURLConnection) new URL(completeUrl).openConnection(proxy);


### PR DESCRIPTION
This pull request is made to :
- add support for proxy when needed in requests
- replace keep-alive setting at JVM level (which can impact other applications) and just set the keep-alive configuration by request.
