### PR TITLE
Fix Java 5 compilation (#318)

### DIFF
--- a/src/main/java/org/scribe/builder/api/ConstantContactApi2.java
+++ b/src/main/java/org/scribe/builder/api/ConstantContactApi2.java
@@ -34,7 +34,6 @@ public class ConstantContactApi2 extends DefaultApi20
     return new AccessTokenExtractor()
     {
 
-      @Override
       public Token extract(String response)
       {
         Preconditions.checkEmptyString(response, "Response body is incorrect. Can't extract a token from an empty string");

--- a/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
+++ b/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
@@ -10,7 +10,6 @@ public class JsonTokenExtractor implements AccessTokenExtractor
 {
   private Pattern accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
 
-  @Override
   public Token extract(String response)
   {
     Preconditions.checkEmptyString(response, "Cannot extract a token from a null or empty String");


### PR DESCRIPTION
I found a previous issue that had explicitly made the code
create 1.5 compatible binaries, so I assume that is the
intended behaviour.
