### PR TITLE
Add authentication to OAuth2ServiceImpl (#317)

### DIFF
--- a/src/main/java/org/scribe/model/SignatureType.java
+++ b/src/main/java/org/scribe/model/SignatureType.java
@@ -3,5 +3,6 @@ package org.scribe.model;
 public enum SignatureType
 {
   Header,
-  QueryString
+  QueryString,
+  Body
 }

--- a/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
@@ -157,6 +157,8 @@ public class OAuth10aServiceImpl implements OAuthService
           request.addQuerystringParameter(entry.getKey(), entry.getValue());
         }
         break;
+      default:
+        throw new UnsupportedOperationException("SignatureType not supported: " + config.getSignatureType());
     }
   }
 }

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -1,15 +1,22 @@
 package org.scribe.oauth;
 
-import org.scribe.builder.api.*;
-import org.scribe.model.*;
+import org.apache.commons.codec.binary.Base64;
+import org.scribe.builder.api.DefaultApi20;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.OAuthConstants;
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Response;
+import org.scribe.model.Token;
+import org.scribe.model.Verifier;
 
 public class OAuth20ServiceImpl implements OAuthService
 {
   private static final String VERSION = "2.0";
-  
+
   private final DefaultApi20 api;
+
   private final OAuthConfig config;
-  
+
   /**
    * Default constructor
    * 
@@ -28,11 +35,11 @@ public class OAuth20ServiceImpl implements OAuthService
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
     OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-    request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
     request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
     request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
-    if(config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
+    if (config.hasScope())
+      request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
+    appendAuthentication(request);
     Response response = request.send();
     return api.getAccessTokenExtractor().extract(response.getBody());
   }
@@ -69,4 +76,33 @@ public class OAuth20ServiceImpl implements OAuthService
     return api.getAuthorizationUrl(config);
   }
 
+  private void appendAuthentication(OAuthRequest request)
+  {
+    switch (config.getSignatureType())
+    {
+    case Header:
+      config.log("using Http Header authentication");
+
+      String oauthHeader = "Basic " + base64Encode(String.format("%s:%s", config.getApiKey(), config.getApiSecret()));
+      request.addHeader(OAuthConstants.HEADER, oauthHeader);
+      break;
+    case QueryString:
+      config.log("using Querystring authentication");
+
+      request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+      break;
+    case Body:
+      config.log("using Body authentication");
+
+      request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+     break;
+    }
+  }
+
+  private String base64Encode(String format)
+  {
+    return new String(Base64.encodeBase64(format.getBytes()));
+  }
 }


### PR DESCRIPTION
The proposed solution overloads the SignatureType enum
(used in OAuth1) as an indicator of authentication type.
This is stretching the terminology a bit, but the OAuth2
support in Scribe does this in other places (like using
Verifier to mean AuthorizationCode), so I assume it's
roughly withing acceptable bounds.
