### PR TITLE
Avoid a mysterious NPE

### DIFF
--- a/src/main/java/org/scribe/model/Response.java
+++ b/src/main/java/org/scribe/model/Response.java
@@ -45,9 +45,11 @@ public class Response
   private Map<String, String> parseHeaders(HttpURLConnection conn)
   {
     Map<String, String> headers = new HashMap<String, String>();
-    for (String key : conn.getHeaderFields().keySet())
+    for (Map.Entry<String, List<String>> entry : conn.getHeaderFields().entrySet())
     {
-      headers.put(key, conn.getHeaderFields().get(key).get(0));
+	  if(entry.getValue() != null) {
+        headers.put(entry.getKey(), entry.getValue().get(0));
+	  }
     }
     return headers;
   }


### PR DESCRIPTION
One user on a particular device was getting an NPE here, meaning that either the header map had a null value, or it was getting mutated in a different thread deleting a key that we expected to be there. I wasn't able to reproduce this locally, but this should protect against any eventuality.
