### PR TITLE
Added support for Trello API.

### DIFF
--- a/src/main/java/org/scribe/builder/api/TrelloApi.java
+++ b/src/main/java/org/scribe/builder/api/TrelloApi.java
@@ -1,0 +1,27 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.*;
+
+public class TrelloApi extends DefaultApi10a
+{
+  private static final String AUTHORIZE_URL = "https://trello.com/1/OAuthAuthorizeToken?oauth_token=%s";
+
+  @Override
+  public String getAccessTokenEndpoint()
+  {
+    return "https://trello.com/1/OAuthGetAccessToken";
+  }
+
+  @Override
+  public String getRequestTokenEndpoint()
+  {
+    return "https://trello.com/1/OAuthGetRequestToken";
+  }
+  
+  @Override
+  public String getAuthorizationUrl(Token requestToken)
+  {
+    return String.format(AUTHORIZE_URL, requestToken.getToken());
+  }
+  
+}

--- a/src/test/java/org/scribe/examples/TrelloExample.java
+++ b/src/test/java/org/scribe/examples/TrelloExample.java
@@ -1,0 +1,60 @@
+package org.scribe.examples;
+
+import java.util.Scanner;
+
+import org.scribe.builder.*;
+import org.scribe.builder.api.*;
+import org.scribe.model.*;
+import org.scribe.oauth.*;
+
+public class TrelloExample
+{
+  private static final String API_KEY = "your_api_key";
+  private static final String API_SECRET = "your_api_secret";
+  private static final String PROTECTED_RESOURCE_URL = "https://trello.com/1/members/me";
+  public static void main(String[] args)
+  {
+    OAuthService service = new ServiceBuilder()
+                                .provider(TrelloApi.class)
+                                .apiKey(API_KEY)
+                                .apiSecret(API_SECRET)
+                                .build();
+    Scanner in = new Scanner(System.in);
+    
+    System.out.println("=== Trello's OAuth Workflow ===");
+    System.out.println();
+
+    // Obtain the Request Token
+    System.out.println("Fetching the Request Token...");
+    Token requestToken = service.getRequestToken();
+    System.out.println("Got the Request Token!");
+    System.out.println();
+
+    System.out.println("Now go and authorize Scribe here:");
+    System.out.println(service.getAuthorizationUrl(requestToken));
+    System.out.println("And paste the verifier here");
+    System.out.print(">>");
+    Verifier verifier = new Verifier(in.nextLine());
+    System.out.println();
+
+    // Trade the Request Token and Verfier for the Access Token
+    System.out.println("Trading the Request Token for an Access Token...");
+    Token accessToken = service.getAccessToken(requestToken, verifier);
+    System.out.println("Got the Access Token!");
+    System.out.println("(if your curious it looks like this: " + accessToken + " )");
+    System.out.println();
+
+    // Now let's go and ask for a protected resource!
+    System.out.println("Now we're going to access a protected resource...");
+    OAuthRequest request = new OAuthRequest(Verb.GET, PROTECTED_RESOURCE_URL);
+    service.signRequest(accessToken, request);
+    Response response = request.send();
+    System.out.println("Got it! Lets see what we found...");
+    System.out.println();
+    System.out.println(response.getBody());
+
+    System.out.println();
+    System.out.println("Thats it man! Go and build something awesome with Scribe! :)");
+  }
+
+}


### PR DESCRIPTION
This includes an example in the style of the other examples, which allows the user to see their member record.  I tested out the example manually.

If you want to get an app key / secret to try it out, you can get it from https://trello.com/1/appKey/generate

Thanks again for Scribe!  It definitely simplifies OAuth.
