### PR TITLE
Google OAuth 2.0 API

### DIFF
--- a/src/main/java/org/scribe/builder/api/GoogleOAuth2Api.java
+++ b/src/main/java/org/scribe/builder/api/GoogleOAuth2Api.java
@@ -1,0 +1,33 @@
+package org.scribe.builder.api;
+
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.Verb;
+import org.scribe.utils.OAuthEncoder;
+import org.scribe.utils.Preconditions;
+
+public class GoogleOAuth2Api extends DefaultApi20 {
+    private static final String AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s";
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.POST;
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return "https://accounts.google.com/o/oauth2/token";
+    }
+
+    @Override
+    public String getAuthorizationUrl(OAuthConfig config) {
+        Preconditions.checkNotNull(config.getScope(), "Must provide a valid scope. Google does not allow empty scopes");
+        return String.format(AUTHORIZATION_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()), OAuthEncoder.encode(config.getScope()));
+    }
+
+    @Override
+    public AccessTokenExtractor getAccessTokenExtractor() {
+        return new JsonTokenExtractor();
+    }
+}

--- a/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
+++ b/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
@@ -1,14 +1,15 @@
 package org.scribe.extractors;
 
-import java.util.regex.*;
+import org.scribe.exceptions.OAuthException;
+import org.scribe.model.Token;
+import org.scribe.utils.Preconditions;
 
-import org.scribe.exceptions.*;
-import org.scribe.model.*;
-import org.scribe.utils.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class JsonTokenExtractor implements AccessTokenExtractor
 {
-  private Pattern accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
+  private Pattern accessTokenPattern = Pattern.compile("\"access_token\"\\s*:\\s*\"(\\S*?)\"");
 
   public Token extract(String response)
   {

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright 2010 Pablo Fernandez
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@ package org.scribe.model;
 
 /**
  * This class contains OAuth constants, used project-wide
- * 
+ *
  * @author Pablo Fernandez
  */
 public class OAuthConstants
@@ -45,5 +45,10 @@ public class OAuthConstants
   public static final String CLIENT_SECRET = "client_secret";
   public static final String REDIRECT_URI = "redirect_uri";
   public static final String CODE = "code";
-  
+  /**
+  * Grant type parameter
+  * http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1.3
+  * https://developers.google.com/accounts/docs/OAuth2InstalledApp#formingtheurl
+  */
+  public static final String GRANT_TYPE = "grant_type";
 }

--- a/src/test/java/org/scribe/examples/GoogleOauth2Example.java
+++ b/src/test/java/org/scribe/examples/GoogleOauth2Example.java
@@ -1,0 +1,64 @@
+package org.scribe.examples;
+
+import org.scribe.builder.ServiceBuilder;
+import org.scribe.builder.api.GoogleOAuth2Api;
+import org.scribe.model.*;
+import org.scribe.oauth.OAuthService;
+
+import java.util.Scanner;
+
+public class GoogleOauth2Example {
+    private static final String NETWORK_NAME = "Google OAuth 2.0";
+    private static final String PROTECTED_RESOURCE_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+    private static final Token EMPTY_TOKEN = null;
+
+    public static void main(String[] args) {
+        // Replace these with your own api key and secret
+        String apiKey = "client_id";
+        String apiSecret = "client_secret";
+        OAuthService service = new ServiceBuilder()
+                .provider(GoogleOAuth2Api.class)
+                .apiKey(apiKey)
+                .apiSecret(apiSecret)
+                .debug()
+                .scope("https://www.googleapis.com/auth/plus.me")
+                .callback("urn:ietf:wg:oauth:2.0:oob")
+                .build();
+        Scanner in = new Scanner(System.in);
+
+        System.out.println("=== " + NETWORK_NAME + "'s OAuth Workflow ===");
+        System.out.println();
+
+        // Obtain the Authorization URL
+        System.out.println("Fetching the Authorization URL...");
+        String authorizationUrl = service.getAuthorizationUrl(EMPTY_TOKEN);
+        System.out.println("Got the Authorization URL!");
+        System.out.println("Now go and authorize Scribe here:");
+        System.out.println(authorizationUrl);
+        System.out.println("And paste the authorization code here");
+        System.out.print(">>");
+        Verifier verifier = new Verifier(in.nextLine());
+        System.out.println();
+
+        // Trade the Request Token and Verfier for the Access Token
+        System.out.println("Trading the Request Token for an Access Token...");
+        Token accessToken = service.getAccessToken(EMPTY_TOKEN, verifier);
+        System.out.println("Got the Access Token!");
+        System.out.println("(if your curious it looks like this: " + accessToken + " )");
+        System.out.println();
+
+        // Now let's go and ask for a protected resource!
+        System.out.println("Now we're going to access a protected resource...");
+        OAuthRequest request = new OAuthRequest(Verb.GET, PROTECTED_RESOURCE_URL);
+        service.signRequest(accessToken, request);
+        Response response = request.send();
+        System.out.println("Got it! Lets see what we found...");
+        System.out.println();
+        System.out.println(response.getCode());
+        System.out.println(response.getBody());
+
+        System.out.println();
+        System.out.println("Thats it man! Go and build something awesome with Scribe! :)");
+
+    }
+}


### PR DESCRIPTION
This commit adds support for Google's oauth 2.0 workflow while avoiding to make scary changes to the rest of the APIs like previous attempts.

It uses an instanceof check to construct an access token request specifically for google's oauth 2.0 endpoint. 

This hack is ok for just this instance (google is a big service, it is worth the ugliness required to support it) but will not scale if other's start adding hacks for each and every Api. If you're interested I have some ideas on how to make this more flexible and scalable.
