### PR TITLE
Add support for ImgUr API version 3.

### DIFF
--- a/src/main/java/org/scribe/builder/api/ImgUr3Api.java
+++ b/src/main/java/org/scribe/builder/api/ImgUr3Api.java
@@ -1,0 +1,55 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.OAuthConfig;
+import org.scribe.oauth.OAuthService;
+import org.scribe.oauth.OAuthImgUr3Impl;
+
+import org.scribe.model.Verb;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.extractors.AccessTokenExtractor;
+
+/**
+ * ImgUr API ver3 (OAuth 2)
+ *
+ * @author Brian Hsu
+ *
+ * @see <a href="http://api.imgur.com/">ImgUr API</a>
+ */
+public class ImgUr3Api extends DefaultApi20 {
+
+  private static final String authorizeURL = "https://api.imgur.com/oauth2/authorize";
+
+  private boolean isOOB(OAuthConfig config) {
+    return "oob".equals(config.getCallback());
+  }
+
+  @Override 
+  public Verb getAccessTokenVerb() { 
+    return Verb.POST;
+  }
+
+  @Override
+  public AccessTokenExtractor getAccessTokenExtractor() { 
+    return new JsonTokenExtractor();
+  }
+
+  @Override
+  public String getAccessTokenEndpoint() { 
+    return "https://api.imgur.com/oauth2/token";
+  }
+
+  @Override
+  public String getAuthorizationUrl(OAuthConfig config) {
+    String apiKey = config.getApiKey();
+    if (isOOB(config)) {
+      return String.format("%s?client_id=%s&response_type=pin", authorizeURL, apiKey);
+    } else {
+      return String.format("%s?client_id=%s&response_type=code", authorizeURL, apiKey);
+    }
+  }
+
+  @Override 
+  public OAuthService createService(OAuthConfig config) {
+    return new OAuthImgUr3Impl(this, config);
+  }
+}

--- a/src/main/java/org/scribe/oauth/OAuthImgUr3Impl.java
+++ b/src/main/java/org/scribe/oauth/OAuthImgUr3Impl.java
@@ -1,0 +1,59 @@
+package org.scribe.oauth;
+
+import org.scribe.builder.api.DefaultApi20;
+
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.OAuthConstants;
+import org.scribe.model.Token;
+import org.scribe.model.Verifier;
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Response;
+
+public class OAuthImgUr3Impl extends OAuth20ServiceImpl {
+
+  private DefaultApi20 api;
+  private OAuthConfig config;
+
+  public OAuthImgUr3Impl(DefaultApi20 api, OAuthConfig config) {
+    super(api, config);
+    this.api = api;
+    this.config = config;
+  }
+
+  private boolean isOOB(OAuthConfig config) {
+    return "oob".equals(config.getCallback());
+  }
+
+  @Override
+  public Token getAccessToken(Token requestToken, Verifier verifier) {
+
+    OAuthRequest request = new OAuthRequest(
+      api.getAccessTokenVerb(), 
+      api.getAccessTokenEndpoint()
+    );
+
+    String grantType = isOOB(config) ? "pin" : "authorization_code";
+
+    // ImgUr API ver 3 using POST to get token, and we need pass
+    // parameters using Body parameter, query string will not work.
+    request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+    request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+    request.addBodyParameter("grant_type", grantType);
+    request.addBodyParameter("pin", verifier.getValue());
+
+    Response response = request.send();
+
+    return api.getAccessTokenExtractor().extract(response.getBody());
+  }
+
+  @Override
+  public void signRequest(Token accessToken, OAuthRequest request) {
+
+    if (accessToken != null) {
+      request.addHeader("Authorization", "Bearer " + accessToken.getToken());
+    } else {
+      request.addHeader("Authorization", "Client-ID " + config.getApiKey());
+    }
+  }
+
+}

--- a/src/test/java/org/scribe/examples/ImgUr3Example.java
+++ b/src/test/java/org/scribe/examples/ImgUr3Example.java
@@ -1,0 +1,53 @@
+package org.scribe.examples;
+
+import org.scribe.builder.*;
+import org.scribe.builder.api.*;
+import org.scribe.model.*;
+import org.scribe.oauth.*;
+
+import java.util.*;
+
+public class ImgUr3Example
+{
+  private static final String PROTECTED_RESOURCE_URL = "https://api.imgur.com/3/account/me/albums";
+  private static final Token EMPTY_TOKEN = null;
+
+  public static void main(String[] args)
+  {
+    // Replace these with your own api key and secret (you'll need an read/write api key)
+    String apiKey = "your_app_id";
+    String apiSecret = "your_api_secret";
+    OAuthService service = new ServiceBuilder().provider(ImgUr3Api.class).apiKey(apiKey).apiSecret(apiSecret).build();
+    Scanner in = new Scanner(System.in);
+
+    System.out.println("=== ImgUr's OAuth Workflow ===");
+    System.out.println();
+
+    System.out.println("Now go and authorize Scribe here:");
+    String authorizationUrl = service.getAuthorizationUrl(EMPTY_TOKEN);
+    System.out.println(authorizationUrl);
+    System.out.println("And paste the verifier here");
+    System.out.print(">>");
+    Verifier verifier = new Verifier(in.nextLine());
+    System.out.println();
+
+    // Trade the Request Token and Verfier for the Access Token
+    System.out.println("Trading the Request Token for an Access Token...");
+    Token accessToken = service.getAccessToken(EMPTY_TOKEN, verifier);
+    System.out.println("Got the Access Token!");
+    System.out.println("(if your curious it looks like this: " + accessToken + " )");
+    System.out.println();
+
+    // Now let's go and ask for a protected resource!
+    System.out.println("Now we're going to access a protected resource...");
+    OAuthRequest request = new OAuthRequest(Verb.GET, PROTECTED_RESOURCE_URL);
+    service.signRequest(accessToken, request);
+    Response response = request.send();
+    System.out.println("Got it! Lets see what we found...");
+    System.out.println();
+    System.out.println(response.getBody());
+
+    System.out.println();
+    System.out.println("Thats it man! Go and build something awesome with Scribe! :)");
+  }
+}


### PR DESCRIPTION
ImgUr API version 3 using OAuth 2.0 and have differnt way to get
access token and sign request.

Main differences:
- When getting authorization URL, we need to pass different
  grant_typ parameter according to whether we have callback URL.
- ImgUr API version 3 using POST to get access token, all
  parameters need to passed as body paramter, query string will
  not work.
- ImgUr API using HTTP header to sign request, so we created
  OAuthImgUr3Impl in order to handle this.
