### PR TITLE
Adding reddit OAuth2 classes

### DIFF
--- a/src/main/java/org/scribe/builder/api/RedditApi.java
+++ b/src/main/java/org/scribe/builder/api/RedditApi.java
@@ -1,0 +1,43 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.OAuthConfig;
+import org.scribe.utils.OAuthEncoder;
+
+public class RedditApi extends DefaultApi20 {
+
+	private static final String AUTHORIZE_URL = "https://ssl.reddit.com/api/v1/authorize";
+	private static final String ACCESS_URL = "https://ssl.reddit.com/api/v1/access_token";
+	private static final String SCOPED_AUTHORIZE_URL = AUTHORIZE_URL + "?client_id=%s&scope=%s&response_type=code&redirect_uri=%s&duration=%s&state=%s";
+
+	//Reddit-specifc OAuth params
+	public boolean isPermanent = false;
+	public String state		   = null;
+	
+	public RedditApi(boolean isPermanent, String state){
+		this.isPermanent = isPermanent;
+		this.state 		 = state;
+	}
+	
+	@Override
+	public String getAccessTokenEndpoint() {
+		return ACCESS_URL;
+	}
+
+	@Override
+	public String getAuthorizationUrl(OAuthConfig config) {
+		//Append scope if present. Reddit permits multiple scopes if comma delimited.
+		if (config.hasScope()) {
+			return String.format(SCOPED_AUTHORIZE_URL,
+					config.getApiKey(),
+					OAuthEncoder.encode(config.getScope()),
+					OAuthEncoder.encode(config.getCallback()),
+					isPermanent ? "permanent" : "temporary",
+					state);
+					
+		} else {
+			return String.format(AUTHORIZE_URL, config.getApiKey(),
+					OAuthEncoder.encode(config.getCallback()));
+		}
+	}
+
+}

--- a/src/test/java/org/scribe/examples/RedditExample.java
+++ b/src/test/java/org/scribe/examples/RedditExample.java
@@ -1,0 +1,48 @@
+package org.scribe.examples;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Scanner;
+
+import org.scribe.builder.ServiceBuilder;
+import org.scribe.builder.api.RedditApi;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.Token;
+import org.scribe.model.Verifier;
+import org.scribe.oauth.OAuthService;
+
+public class RedditExample {
+
+	private static final String NETWORK_NAME = "Reddit";	
+	
+	public static void main(String[] args) {
+		// Replace these with your own api key and secret
+		String apiKey = "QkLVfwQPQ-8v1A";
+		String apiSecret = "-tNL7x9tB6m1wa7wH5Dmjtp7nnc";
+
+		//For sufficiently random + secure 'state' strings http://stackoverflow.com/questions/41107/how-to-generate-a-random-alpha-numeric-string
+		SecureRandom random = new SecureRandom();
+		BigInteger randomInt = new BigInteger(128, random);
+		
+		OAuthConfig config = new OAuthConfig(apiKey, apiSecret, "http://com.cd.reddit-super-sleuth", null, "identity", null);		
+		
+		RedditApi service = new RedditApi(true, randomInt.toString(32));
+		
+		Scanner in = new Scanner(System.in);
+		
+	    System.out.println("=== " + NETWORK_NAME + "'s OAuth Workflow ===");
+	    System.out.println();		
+
+	    // Obtain the Authorization URL
+	    System.out.println("Fetching the Authorization URL...");
+	    String authorizationUrl = service.getAuthorizationUrl(config);
+	    System.out.println("Got the Authorization URL!");
+	    System.out.println("Now go and authorize Scribe here:");
+	    System.out.println(authorizationUrl);
+	    System.out.println("And paste the authorization code here");
+	    System.out.print(">>");
+	    Verifier verifier = new Verifier(in.nextLine());
+	    System.out.println();	    
+	}
+
+}


### PR DESCRIPTION
Hey Fernandez,

So I decided I wanted to make a Reddit bot and started making a Reddit OAuth2 implementation for Scribe. Only after getting most of the work done (its really not much) did I realize that a bot does not use OAuth by definition - since a bot will have it's own user account, I can just login the 'normal' way and not use OAuth authentication.

Rather than throw away this work, I'd like to submit this pull request. If anything is not up to par please let me know.
