### PR TITLE
Add support for the Authorization parameter 'realm'

### DIFF
--- a/src/main/java/org/scribe/extractors/HeaderExtractorImpl.java
+++ b/src/main/java/org/scribe/extractors/HeaderExtractorImpl.java
@@ -35,6 +35,13 @@ public class HeaderExtractorImpl implements HeaderExtractor
       }
       header.append(String.format("%s=\"%s\"", entry.getKey(), OAuthEncoder.encode(entry.getValue())));
     }
+    
+    if (request.getRealm() != null && !request.getRealm().isEmpty())
+    {
+      header.append(PARAM_SEPARATOR);
+      header.append(String.format("%s=\"%s\"", OAuthConstants.REALM, request.getRealm()));
+    }
+        
     return header.toString();
   }
 

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -32,6 +32,7 @@ public class OAuthConstants
   public static final String CALLBACK = "oauth_callback";
   public static final String VERSION = "oauth_version";
   public static final String NONCE = "oauth_nonce";
+  public static final String REALM = "realm";
   public static final String PARAM_PREFIX = "oauth_";
   public static final String TOKEN = "oauth_token";
   public static final String TOKEN_SECRET = "oauth_token_secret";

--- a/src/main/java/org/scribe/model/OAuthRequest.java
+++ b/src/main/java/org/scribe/model/OAuthRequest.java
@@ -13,7 +13,8 @@ public class OAuthRequest extends Request
 {
   private static final String OAUTH_PREFIX = "oauth_";
   private Map<String, String> oauthParameters;
-
+  private String realm;
+  
   /**
    * Default constructor.
    * 
@@ -61,6 +62,16 @@ public class OAuthRequest extends Request
     return oauthParameters;
   }
 
+  public void setRealm(String realm) 
+  {
+    this.realm = realm;
+  }
+  
+  public String getRealm() 
+  {
+    return realm;
+  }
+  
   @Override
   public String toString()
   {


### PR DESCRIPTION
The realm parameter is required when interacting with some OAuth 1.0 APIs. This change allows an optional realm to be set on an OAuthRequest, and if set then the realm will be included when generating an Authorization header value.

Realm is also essential when APIs support multiple token providers, as the realm value identifies the provider.
