### PR TITLE
no need to use .toLowerCase() and .compareToIgnoreCase() on the same string

### DIFF
--- a/src/main/java/org/scribe/utils/Preconditions.java
+++ b/src/main/java/org/scribe/utils/Preconditions.java
@@ -65,7 +65,7 @@ public class Preconditions
   public static void checkValidOAuthCallback(String url, String errorMsg)
   {
     checkEmptyString(url, errorMsg);
-    if(url.toLowerCase().compareToIgnoreCase(OAuthConstants.OUT_OF_BAND) != 0)
+    if(url.compareToIgnoreCase(OAuthConstants.OUT_OF_BAND) != 0)
     {
       check(isUrl(url), errorMsg);  
     }


### PR DESCRIPTION
using compareToIgnoreCase() removes the need to call toLowerCase(), just removed.
