### PR TITLE
Update TwitterApi.java

### DIFF
--- a/src/main/java/org/scribe/builder/api/TwitterApi.java
+++ b/src/main/java/org/scribe/builder/api/TwitterApi.java
@@ -11,13 +11,13 @@ public class TwitterApi extends DefaultApi10a
   @Override
   public String getAccessTokenEndpoint()
   {
-    return "http://" + ACCESS_TOKEN_RESOURCE;
+    return "https://" + ACCESS_TOKEN_RESOURCE;
   }
 
   @Override
   public String getRequestTokenEndpoint()
   {
-    return "http://" + REQUEST_TOKEN_RESOURCE;
+    return "https://" + REQUEST_TOKEN_RESOURCE;
   }
 
   @Override


### PR DESCRIPTION
Now using https since this is required by Twitter since January the 14th. See: https://dev.twitter.com/discussions/24239.
