### PR TITLE
Update TwitterApi.java

### DIFF
--- a/src/main/java/org/scribe/builder/api/TwitterApi.java
+++ b/src/main/java/org/scribe/builder/api/TwitterApi.java
@@ -29,7 +29,7 @@ public class TwitterApi extends DefaultApi10a
   /**
    * Twitter 'friendlier' authorization endpoint for OAuth.
    */
-  public static class Authenticate
+  public static class Authenticate extends TwitterApi
   {
     private static final String AUTHENTICATE_URL = "https://api.twitter.com/oauth/authenticate?oauth_token=%s";
 


### PR DESCRIPTION
- Changed the request and access token endpoints to https.
- Removed the inner SSL class since Twitter now forces to use https instead of http.
- Removed the extend SSL from the Authenticate class since it no longer exists anymore.
