### PR TITLE
connecting to api.twitter.com over SSL

### DIFF
--- a/src/test/java/org/scribe/examples/TwitterExample.java
+++ b/src/test/java/org/scribe/examples/TwitterExample.java
@@ -15,7 +15,7 @@ public class TwitterExample
   {
     // If you choose to use a callback, "oauth_verifier" will be the return value by Twitter (request param)
     OAuthService service = new ServiceBuilder()
-                                .provider(TwitterApi.class)
+                                .provider(TwitterApi.SSL.class)
                                 .apiKey("6icbcAXyZx67r8uTAUM5Qw")
                                 .apiSecret("SCCAdUUc6LXxiazxH3N0QfpNUvlUy84mZ2XZKiv39s")
                                 .build();


### PR DESCRIPTION
"api.twitter.com"  is restricted to TLS/SSL connections only on January 14th, 2014.
so, I fixed "TwitterExample" 

https://dev.twitter.com/discussions/24239
