### PR TITLE
Add methods getRequestToken and getAccessToken with RequestTuner parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.scribe</groupId>
   <artifactId>scribe</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.5</version>
+  <version>1.3.6-SNAPSHOT</version>
   <name>Scribe OAuth Library</name>
   <description>The best OAuth library out there</description>
   <url>http://github.com/fernandezpablo85/scribe-java</url>

--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -17,9 +17,6 @@ public class Request
 {
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String CONTENT_TYPE = "Content-Type";
-  private static RequestTuner NOOP = new RequestTuner() {
-    @Override public void tune(Request _){}
-  };
   public static final String DEFAULT_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
   private String url;
@@ -73,7 +70,7 @@ public class Request
 
   public Response send()
   {
-    return send(NOOP);
+    return send(null);
   }
 
   private void createConnection() throws IOException
@@ -108,12 +105,15 @@ public class Request
     {
       connection.setReadTimeout(readTimeout.intValue());
     }
+    if (tuner != null) {
+        tuner.tune(this);
+    }
+    
     addHeaders(connection);
     if (verb.equals(Verb.PUT) || verb.equals(Verb.POST))
     {
       addBody(connection, getByteBodyContents());
     }
-    tuner.tune(this);
     return new Response(connection);
   }
 

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -27,13 +27,21 @@ public class OAuth20ServiceImpl implements OAuthService
    */
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
+      return getAccessToken(requestToken, verifier, null);
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public Token getAccessToken(Token requestToken, Verifier verifier, RequestTuner tuner)
+  {
     OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
     request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
     request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
     request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
     request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
     if(config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
-    Response response = request.send();
+    Response response = request.send(tuner);
     return api.getAccessTokenExtractor().extract(response.getBody());
   }
 
@@ -41,6 +49,14 @@ public class OAuth20ServiceImpl implements OAuthService
    * {@inheritDoc}
    */
   public Token getRequestToken()
+  {
+    throw new UnsupportedOperationException("Unsupported operation, please use 'getAuthorizationUrl' and redirect your users there");
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  public Token getRequestToken(RequestTuner tuner)
   {
     throw new UnsupportedOperationException("Unsupported operation, please use 'getAuthorizationUrl' and redirect your users there");
   }

--- a/src/main/java/org/scribe/oauth/OAuthService.java
+++ b/src/main/java/org/scribe/oauth/OAuthService.java
@@ -17,6 +17,14 @@ public interface OAuthService
    * @return request token
    */
   public Token getRequestToken();
+  
+  /**
+   * Retrieve the request token.
+   * 
+   * @param tuner the tuner of the request
+   * @return request token
+   */
+  public Token getRequestToken(RequestTuner tuner);
 
   /**
    * Retrieve the access token
@@ -26,6 +34,16 @@ public interface OAuthService
    * @return access token
    */
   public Token getAccessToken(Token requestToken, Verifier verifier);
+  
+  /**
+   * Retrieve the access token
+   * 
+   * @param requestToken request token (obtained previously)
+   * @param verifier verifier code
+   * @param tuner the tuner of the request
+   * @return access token
+   */
+  public Token getAccessToken(Token requestToken, Verifier verifier, RequestTuner tuner);
 
   /**
    * Signs am OAuth request


### PR DESCRIPTION
As discussed by email here is the modification I've done :

Add methods getRequestToken and getAccessToken with RequestTuner parameter in interface OAuthService

Implements those methods in OAuth20ServiceImpl

Call the tuner.tune(this) in the send method of the Request class earlier (with nullity check).