### PR TITLE
Add an abstraction around the implementation of sending HTTP requests

### DIFF
--- a/src/main/java/org/scribe/builder/api/DefaultApi10a.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi10a.java
@@ -138,4 +138,9 @@ public abstract class DefaultApi10a implements Api
   {
     return new OAuth10aServiceImpl(this, config);
   }
+
+  public RequestSender getRequestSender()
+  {
+    return UrlConnectionRequestSender.INSTANCE;
+  }
 }

--- a/src/main/java/org/scribe/model/RequestSender.java
+++ b/src/main/java/org/scribe/model/RequestSender.java
@@ -1,0 +1,10 @@
+package org.scribe.model;
+
+import java.io.IOException;
+
+public abstract class RequestSender
+{
+
+  public abstract Response send(Request request, RequestTuner tuner) throws IOException;
+
+}

--- a/src/main/java/org/scribe/model/Response.java
+++ b/src/main/java/org/scribe/model/Response.java
@@ -1,11 +1,10 @@
 package org.scribe.model;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
 
-import org.scribe.exceptions.*;
-import org.scribe.utils.*;
+import org.scribe.utils.StreamUtils;
 
 /**
  * Represents an HTTP Response.
@@ -14,44 +13,24 @@ import org.scribe.utils.*;
  */
 public class Response
 {
-  private static final String EMPTY = "";
-
   private int code;
   private String message;
   private String body;
   private InputStream stream;
   private Map<String, String> headers;
 
-  Response(HttpURLConnection connection) throws IOException
+  Response(int code, String message, InputStream stream, Map<String, String> headers) throws IOException
   {
-    try
-    {
-      connection.connect();
-      code = connection.getResponseCode();
-      message = connection.getResponseMessage();
-      headers = parseHeaders(connection);
-      stream = isSuccessful() ? connection.getInputStream() : connection.getErrorStream();
-    }
-    catch (UnknownHostException e)
-    {
-      throw new OAuthException("The IP address of a host could not be determined.", e);
-    }
+    this.code = code;
+    this.message = message;
+    this.stream = stream;
+    this.headers = headers;
   }
 
   private String parseBodyContents()
   {
     body = StreamUtils.getStreamContents(getStream());
     return body;
-  }
-
-  private Map<String, String> parseHeaders(HttpURLConnection conn)
-  {
-    Map<String, String> headers = new HashMap<String, String>();
-    for (String key : conn.getHeaderFields().keySet())
-    {
-      headers.put(key, conn.getHeaderFields().get(key).get(0));
-    }
-    return headers;
   }
 
   public boolean isSuccessful()

--- a/src/main/java/org/scribe/model/UrlConnectionRequestSender.java
+++ b/src/main/java/org/scribe/model/UrlConnectionRequestSender.java
@@ -1,0 +1,96 @@
+package org.scribe.model;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.scribe.exceptions.OAuthException;
+
+public class UrlConnectionRequestSender extends RequestSender
+{
+  public static final UrlConnectionRequestSender INSTANCE = new UrlConnectionRequestSender();
+
+  @Override
+  public Response send(Request request, RequestTuner tuner) throws IOException
+  {
+    HttpURLConnection connection = createConnection(request);
+    connection.setRequestMethod(request.getVerb().name());
+    if (request.getConnectTimeout() != null)
+    {
+      connection.setConnectTimeout(request.getConnectTimeout().intValue());
+    }
+    if (request.getReadTimeout() != null)
+    {
+      connection.setReadTimeout(request.getReadTimeout().intValue());
+    }
+    addHeaders(request, connection);
+    if (request.getVerb().equals(Verb.PUT) || request.getVerb().equals(Verb.POST))
+    {
+      addBody(connection, request.getByteBodyContents());
+    }
+    tuner.tune(request);
+
+    return getResponse(connection);
+  }
+
+  HttpURLConnection createConnection(Request request) throws IOException, MalformedURLException
+  {
+    String completeUrl = request.getCompleteUrl();
+    System.setProperty("http.keepAlive", request.isConnectionKeepAlive() ? "true" : "false");
+    HttpURLConnection connection = (HttpURLConnection) new URL(completeUrl).openConnection();
+    connection.setInstanceFollowRedirects(request.isFollowRedirects());
+    return connection;
+  }
+
+  private void addHeaders(Request request, HttpURLConnection conn)
+  {
+    for (String key : request.getHeaders().keySet())
+      conn.setRequestProperty(key, request.getHeaders().get(key));
+  }
+
+  private void addBody(HttpURLConnection conn, byte[] content) throws IOException
+  {
+    conn.setRequestProperty(Request.CONTENT_LENGTH, String.valueOf(content.length));
+
+    // Set default content type if none is set.
+    if (conn.getRequestProperty(Request.CONTENT_TYPE) == null)
+    {
+      conn.setRequestProperty(Request.CONTENT_TYPE, Request.DEFAULT_CONTENT_TYPE);
+    }
+    conn.setDoOutput(true);
+    conn.getOutputStream().write(content);
+  }
+
+  Response getResponse(HttpURLConnection connection) throws IOException
+  {
+    try
+    {
+      connection.connect();
+      int code = connection.getResponseCode();
+      String message = connection.getResponseMessage();
+      Map<String, String> headers = parseHeaders(connection);
+      boolean successful = code >= 200 && code < 400;
+      InputStream stream = successful ? connection.getInputStream() : connection.getErrorStream();
+      return new Response(code, message, stream, headers);
+    } catch (UnknownHostException e)
+    {
+      throw new OAuthException("The IP address of a host could not be determined.", e);
+    }
+  }
+
+  private Map<String, String> parseHeaders(HttpURLConnection conn)
+  {
+    Map<String, String> headers = new HashMap<String, String>();
+    for (String key : conn.getHeaderFields().keySet())
+    {
+      headers.put(key, conn.getHeaderFields().get(key).get(0));
+    }
+    return headers;
+  }
+
+}

--- a/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth10aServiceImpl.java
@@ -56,7 +56,7 @@ public class OAuth10aServiceImpl implements OAuthService
     appendSignature(request);
 
     config.log("sending request...");
-    Response response = request.send(tuner);
+    Response response = request.send(api.getRequestSender(), tuner);
     String body = response.getBody();
 
     config.log("response status code: " + response.getCode());
@@ -102,7 +102,7 @@ public class OAuth10aServiceImpl implements OAuthService
     appendSignature(request);
     
     config.log("sending request...");
-    Response response = request.send(tuner);
+    Response response = request.send(api.getRequestSender(), tuner);
     String body = response.getBody();
     
     config.log("response status code: " + response.getCode());

--- a/src/test/java/org/scribe/model/RequestTest.java
+++ b/src/test/java/org/scribe/model/RequestTest.java
@@ -9,23 +9,23 @@ public class RequestTest
   private Request getRequest;
   private Request postRequest;
   private ConnectionStub connection;
+  private UrlConnectionRequestSenderStub sender;
 
   @Before
   public void setup() throws Exception
   {
     connection = new ConnectionStub();
+    sender = new UrlConnectionRequestSenderStub(connection);
     postRequest = new Request(Verb.POST, "http://example.com");
     postRequest.addBodyParameter("param", "value");
     postRequest.addBodyParameter("param with spaces", "value with spaces");
-    postRequest.setConnection(connection);
     getRequest = new Request(Verb.GET, "http://example.com?qsparam=value&other+param=value+with+spaces");
-    getRequest.setConnection(connection);
   }
 
   @Test
   public void shouldSetRequestVerb()
   {
-    getRequest.send();
+    getRequest.send(sender, Request.NOOP);
     assertEquals("GET", connection.getRequestMethod());
   }
 
@@ -42,7 +42,7 @@ public class RequestTest
   {
     getRequest.addHeader("Header", "1");
     getRequest.addHeader("Header2", "2");
-    getRequest.send();
+    getRequest.send(sender, Request.NOOP);
     assertEquals(2, getRequest.getHeaders().size());
     assertEquals(2, connection.getHeaders().size());
   }
@@ -51,7 +51,7 @@ public class RequestTest
   public void shouldSetBodyParamsAndAddContentLength()
   {
     assertEquals("param=value&param%20with%20spaces=value%20with%20spaces", postRequest.getBodyContents());
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertTrue(connection.getHeaders().containsKey("Content-Length"));
   }
 
@@ -59,7 +59,7 @@ public class RequestTest
   public void shouldSetPayloadAndHeaders()
   {
     postRequest.addPayload("PAYLOAD");
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertEquals("PAYLOAD", postRequest.getBodyContents());
     assertTrue(connection.getHeaders().containsKey("Content-Length"));
   }
@@ -92,7 +92,7 @@ public class RequestTest
   public void shouldAutomaticallyAddContentTypeForPostRequestsWithBytePayload()
   {
     postRequest.addPayload("PAYLOAD".getBytes());
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertEquals(Request.DEFAULT_CONTENT_TYPE, connection.getHeaders().get("Content-Type"));
   }
 
@@ -100,14 +100,14 @@ public class RequestTest
   public void shouldAutomaticallyAddContentTypeForPostRequestsWithStringPayload()
   {
     postRequest.addPayload("PAYLOAD");
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertEquals(Request.DEFAULT_CONTENT_TYPE, connection.getHeaders().get("Content-Type"));
   }
 
   @Test
   public void shouldAutomaticallyAddContentTypeForPostRequestsWithBodyParameters()
   {
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertEquals(Request.DEFAULT_CONTENT_TYPE, connection.getHeaders().get("Content-Type"));
   }
 
@@ -115,14 +115,14 @@ public class RequestTest
   public void shouldBeAbleToOverrideItsContentType()
   {
     postRequest.addHeader("Content-Type", "my-content-type");
-    postRequest.send();
+    postRequest.send(sender, Request.NOOP);
     assertEquals("my-content-type", connection.getHeaders().get("Content-Type"));
   }
 
   @Test
   public void shouldNotAddContentTypeForGetRequests()
   {
-    getRequest.send();
+    getRequest.send(sender, Request.NOOP);
     assertFalse(connection.getHeaders().containsKey("Content-Type"));
   }
 }

--- a/src/test/java/org/scribe/model/ResponseTest.java
+++ b/src/test/java/org/scribe/model/ResponseTest.java
@@ -11,6 +11,7 @@ public class ResponseTest
 
   private Response response;
   private ConnectionStub connection;
+  private UrlConnectionRequestSenderStub sender;
 
   @Before
   public void setup() throws Exception
@@ -18,7 +19,8 @@ public class ResponseTest
     connection = new ConnectionStub();
     connection.addResponseHeader("one", "one");
     connection.addResponseHeader("two", "two");
-    response = new Response(connection);
+    sender = new UrlConnectionRequestSenderStub(connection);
+    response = sender.getResponse(connection);
   }
 
   @Test
@@ -47,7 +49,7 @@ public class ResponseTest
   @Test
   public void shouldHandleAConnectionWithErrors() throws Exception
   {
-    Response errResponse = new Response(new FaultyConnection());
+    Response errResponse = sender.getResponse(new FaultyConnection());
     assertEquals(400, errResponse.getCode());
     assertEquals("errors", errResponse.getBody());
   }

--- a/src/test/java/org/scribe/model/UrlConnectionRequestSenderStub.java
+++ b/src/test/java/org/scribe/model/UrlConnectionRequestSenderStub.java
@@ -1,0 +1,21 @@
+package org.scribe.model;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+
+public class UrlConnectionRequestSenderStub extends UrlConnectionRequestSender
+{
+  private ConnectionStub connection;
+
+  public UrlConnectionRequestSenderStub(ConnectionStub connection)
+  {
+    this.connection = connection;
+  }
+
+  @Override
+  HttpURLConnection createConnection(Request request) throws IOException, MalformedURLException
+  {
+    return connection;
+  }
+}


### PR DESCRIPTION
Used in an heavy multithreaded environment, we had issues with HttpUrlConnection. Using Apache HttpClient fixed our issues. Hence the suggested path, which introduce the abstraction of sending an HTTP request.
The API has been kept backward compatible, tests still pass.