### PR TITLE
Introduce new ConnectionFactory/RequestFactory interfaces

### DIFF
--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -41,6 +41,7 @@ public class OAuthConstants
   public static final String HEADER = "Authorization";
   public static final Token EMPTY_TOKEN = new Token("", "");
   public static final String SCOPE = "scope";
+  public static final String SESSION_HANDLE = "oauth_session_handle";
 
   //OAuth 2.0
   public static final String ACCESS_TOKEN = "access_token";

--- a/src/main/java/org/scribe/model/OAuthRequest.java
+++ b/src/main/java/org/scribe/model/OAuthRequest.java
@@ -1,6 +1,10 @@
 package org.scribe.model;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.scribe.services.ConnectionFactory;
+import org.scribe.services.DefaultConnectionFactory;
 
 /**
  * The representation of an OAuth HttpRequest.
@@ -23,7 +27,19 @@ public class OAuthRequest extends Request
    */
   public OAuthRequest(Verb verb, String url)
   {
-    super(verb, url);
+    this(verb, url, new DefaultConnectionFactory());
+  }
+
+  /**
+   * Creates a new OAuthRequest with custom {@link ConnectionFactory}
+   * 
+   * @param verb Http verb/method
+   * @param url resource URL
+   * @param connectionFactory Responsible for creating HTTP connections
+   */
+  public OAuthRequest(Verb verb, String url, ConnectionFactory connectionFactory)
+  {
+    super(verb, url, connectionFactory);
     this.oauthParameters = new HashMap<String, String>();
   }
 

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -1,7 +1,14 @@
 package org.scribe.oauth;
 
-import org.scribe.builder.api.*;
-import org.scribe.model.*;
+import org.scribe.builder.api.DefaultApi20;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.OAuthConstants;
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Response;
+import org.scribe.model.Token;
+import org.scribe.model.Verifier;
+import org.scribe.services.DefaultRequestFactory;
+import org.scribe.services.RequestFactory;
 
 public class OAuth20ServiceImpl implements OAuthService
 {
@@ -9,6 +16,7 @@ public class OAuth20ServiceImpl implements OAuthService
   
   private final DefaultApi20 api;
   private final OAuthConfig config;
+  protected final RequestFactory requestFactory;
   
   /**
    * Default constructor
@@ -18,8 +26,21 @@ public class OAuth20ServiceImpl implements OAuthService
    */
   public OAuth20ServiceImpl(DefaultApi20 api, OAuthConfig config)
   {
+    this(api, config, new DefaultRequestFactory());
+  }
+
+  /**
+   * Creates a new OAuth20ServiceImpl with custom {@link RequestFactory}
+   *
+   * @param api OAuth2.0 api information
+   * @param config OAuth 2.0 configuration param object
+   * @param requestFactory Responsible for creating {@link OAuthRequest}s
+   */
+  public OAuth20ServiceImpl(DefaultApi20 api, OAuthConfig config, RequestFactory requestFactory)
+  {
     this.api = api;
     this.config = config;
+    this.requestFactory = requestFactory;
   }
 
   /**
@@ -27,7 +48,7 @@ public class OAuth20ServiceImpl implements OAuthService
    */
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
-    OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
+    OAuthRequest request = requestFactory.createRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
     request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
     request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
     request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());

--- a/src/main/java/org/scribe/services/ConnectionFactory.java
+++ b/src/main/java/org/scribe/services/ConnectionFactory.java
@@ -1,0 +1,10 @@
+package org.scribe.services;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+
+public interface ConnectionFactory
+{
+  HttpURLConnection createConnection(String url) throws MalformedURLException, IOException;
+}

--- a/src/main/java/org/scribe/services/DefaultConnectionFactory.java
+++ b/src/main/java/org/scribe/services/DefaultConnectionFactory.java
@@ -1,0 +1,14 @@
+package org.scribe.services;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class DefaultConnectionFactory implements ConnectionFactory
+{
+  public HttpURLConnection createConnection(String url) throws MalformedURLException, IOException
+  {
+    return (HttpURLConnection) new URL(url).openConnection();
+  }
+}

--- a/src/main/java/org/scribe/services/DefaultRequestFactory.java
+++ b/src/main/java/org/scribe/services/DefaultRequestFactory.java
@@ -1,0 +1,12 @@
+package org.scribe.services;
+
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Verb;
+
+public class DefaultRequestFactory implements RequestFactory
+{
+  public OAuthRequest createRequest(Verb verb, String url)
+  {
+    return new OAuthRequest(verb, url);
+  }
+}

--- a/src/main/java/org/scribe/services/RequestFactory.java
+++ b/src/main/java/org/scribe/services/RequestFactory.java
@@ -1,0 +1,9 @@
+package org.scribe.services;
+
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Verb;
+
+public interface RequestFactory
+{
+    OAuthRequest createRequest(Verb verb, String url);
+}


### PR DESCRIPTION
These interfaces used to create instances of `HttpURLConnection` and `OAuthRequest` respectively

I was trying to set custom [`SSLSocketFactory` for `HttpsURLConnection`](http://docs.oracle.com/javase/7/docs/api/javax/net/ssl/HttpsURLConnection.html#setSSLSocketFactory(javax.net.ssl.SSLSocketFactory)) to setup certificate authentication while establishing secured connection, but found it's impossible using current implementation.

I tried using `RequestTuner` (getting `HttpsURLConnection` from request instance using reflection), but found it was too late for setting `SSLSocketFactory`, because connection was already opened by [`addBody(...)`](https://github.com/fernandezpablo85/scribe-java/blob/60aa4bb714a291a4694fc27085017ed83b00bbc3/src/main/java/org/scribe/model/Request.java#L114).

The change is implemented in a backward compatible way, so no existing clients should be affected.

The reason for two interfaces is that in Scribe's current implementation `Request` object is responsible for creating and configuring `HttpURLConnection`, so I decided to keep this behavior in favor of backwards compatibility and simply delegating call of `new URL(url).openConnection()` to new `ConnectionFactory#createConnection(url)`.

So in order to use custom `ConnectionFactory` you should implement custom `RequestFactory` interface where you create new `OAuthRequest` by passing this custom connection factory to `OAuthRequest`'s constructor.

Here's an example of using custom factories from real-life application: https://gist.github.com/dmitrygusev/388040ea136338bc8cea