### PR TITLE
Remove Request#setConnectionKeepAlive()

### DIFF
--- a/src/main/java/org/scribe/model/Request.java
+++ b/src/main/java/org/scribe/model/Request.java
@@ -31,7 +31,6 @@ public class Request
   private HttpURLConnection connection;
   private String charset;
   private byte[] bytePayload = null;
-  private boolean connectionKeepAlive = false;
   private boolean followRedirects = true;
   private Long connectTimeout = null;
   private Long readTimeout = null;
@@ -81,7 +80,6 @@ public class Request
     String completeUrl = getCompleteUrl();
     if (connection == null)
     {
-      System.setProperty("http.keepAlive", connectionKeepAlive ? "true" : "false");
       connection = (HttpURLConnection) new URL(completeUrl).openConnection();
       connection.setInstanceFollowRedirects(followRedirects);
     }
@@ -348,17 +346,6 @@ public class Request
   public void setCharset(String charsetName)
   {
     this.charset = charsetName;
-  }
-
-  /**
-   * Sets whether the underlying Http Connection is persistent or not.
-   *
-   * @see http://download.oracle.com/javase/1.5.0/docs/guide/net/http-keepalive.html
-   * @param connectionKeepAlive
-   */
-  public void setConnectionKeepAlive(boolean connectionKeepAlive)
-  {
-    this.connectionKeepAlive = connectionKeepAlive;
   }
 
   /**


### PR DESCRIPTION
Oracle JDK defaults [`http.keepAlive`](https://docs.oracle.com/javase/8/docs/technotes/guides/net/http-keepalive.html) to `true`. Scribe implicitly **modifies this behaviour globally at runtime** by setting the system property to `false` (by default) in [`Request.java#createConnection()`](https://github.com/fernandezpablo85/scribe-java/blob/master/src/main/java/org/scribe/model/Request.java#L84) to fix [some unspecified pre-Gingerbread connection problem](https://github.com/fernandezpablo85/scribe-java/commit/145c009fc3734958d18625286f31e43fc19e8734).

In my oppinion scribe model must not tamper with JDK defaults and hence `connectionKeepAlive` property has to be removed.
