### PR TITLE
Turn off Java8 doclint, see http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,4 +158,26 @@
         </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- http://stackoverflow.com/a/22296107/122441 -->
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <!-- http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html -->
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Turn off Java8 doclint, see http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
