### PR TITLE
Send the params in a url-encoded form in case of POST or PUT request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,110 +1,52 @@
-# Welcome to the home of Scribe, the simple OAuth Java lib!
+# Welcome to the home of Scribe-sc, the simple OAuth Java lib forked by the Scenari Team!
 
-![travis ci](https://secure.travis-ci.org/fernandezpablo85/scribe-java.png?branch=master)
-[![codecov.io](https://codecov.io/github/fernandezpablo85/scribe-java/coverage.svg?branch=master)](https://codecov.io/github/fernandezpablo85/scribe-java?branch=master)
+### To understand scribe, please read the master github page (https://github.com/fernandezpablo85/scribe-java)
 
-### Before submitting a pull request [please read this](https://github.com/fernandezpablo85/scribe-java/wiki/Scribe-scope-revised)
+# Why a fork for Scribe ?
 
-# Why use Scribe?
+Basically, because the support of OAuth 2 by Scribe is not as wide as the standard defines it. This fork aims to enhance the Oauth 2 support, especially by letting the API classes interact with the Oauth2 service to specialize the access token request or sign in request.
 
-### Dead Simple
+### What is different in Scribe-sc
 
-Who said OAuth was difficult? Configuring scribe is __so easy your grandma can do it__! check it out:
+In an API class, you can define how the access token request should be signed.
 
 ```java
-OAuthService service = new ServiceBuilder()
-                                  .provider(LinkedInApi.class)
-                                  .apiKey(YOUR_API_KEY)
-                                  .apiSecret(YOUR_API_SECRET)
-                                  .build();
+
+	@Override
+	public ParameterType getClientAuthenticationType() {
+	
+	// ParameterType.Header => the token cliendId:clientSecret is base64 encoded and send as a Basic Auth
+	// ParameterType.QueryString => cliendId and clientSecret are sent as a oauth parameter in the QueryString
+	// ParameterType.PostForm => cliendId and clientSecret are sent as a oauth parameter in a URL encoded form
+	
+		return ParameterType.Header;
+	}
+	//Default is QueryString for backward compatibility
 ```
 
-That **single line** (added newlines for readability) is the only thing you need to configure scribe with LinkedIn's OAuth API for example.
+You can define how the oauth 2 parameters should be sent.
+```java
 
-### Threadsafe
-
-Hit Scribe as hard and with many threads as you like.
-
-### Supports all major 1.0a and 2.0 OAuth APIs out-of-the-box
-
-* Google
-
-* Facebook
-
-* Yahoo
-
-* LinkedIn
-
-* Twitter
-
-* Foursquare
-
-* Evernote
-
-* Vimeo
-
-* Windows Live
-
-* and many more! check the [examples folder](http://github.com/fernandezpablo85/scribe-java/tree/master/src/test/java/org/scribe/examples)
-
-### Small and modular
-
-Scribe's code is small (about 1k LOC) and simple to understand. No smart-ass or "clever" hacks here.
-
-### Android-Ready
-
-Works out of the box with android(TM) applications.
-
-### Stable & bulletproof
-
-Good test coverage to keep you safe from harm.
-
-When something bad actually happens, Scribe's meaningful error messages will tell you exactly what went wrong, when and where.
-
-### Pull it from Maven!
-
-You can pull scribe from my maven repository, just add these to your __pom.xml__ file:
-
-```xml
-
-<!-- repository -->
-<repositories>
-  <repository>
-    <id>scribe-java-mvn-repo</id>
-    <url>https://raw.github.com/fernandezpablo85/scribe-java/mvn-repo/</url>
-    <snapshots>
-      <enabled>true</enabled>
-      <updatePolicy>always</updatePolicy>
-    </snapshots>
-  </repository>
-</repositories>
-
-<!-- dependency -->
-<dependency>
-  <groupId>org.scribe</groupId>
-  <artifactId>scribe</artifactId>
-  <version>1.3.6</version>
-</dependency>
+	@Override
+	public ParameterType getParameterType() {
+	
+	// ParameterType.Header => the parameters are sent in the header
+	// ParameterType.QueryString => the parameters are sent as a QueryString
+	// ParameterType.PostForm => The parameters are sent in a URL encoded form
+	
+		return ParameterType.Header;
+	}
+	//Default is QueryString for backward compatibility
 ```
 
-## Getting started in less than 2 minutes
+Finally, you can throw the access token request of the service and build your own.
+```java
 
-Check the [Getting Started](http://wiki.github.com/fernandezpablo85/scribe-java/getting-started) page and start rocking! Please Read the [FAQ](http://wiki.github.com/fernandezpablo85/scribe-java/faq) before creating an issue :)
+	@Override
+	public OAuthRequest handleRequest(OAuthRequest request) {
+	//Do what ever you want on the access token request here. The service will not change it. 
+	  return request;
+	}
+```
 
-Also, remember to read the [fantastic tutorial](http://akoskm.github.io/2015/07/31/twitter-sign-in-for-web-apps.html) that [@akoskm](https://twitter.com/akoskm) wrote to easily integrate a server side app with an API (twitter in this case).
 
-## Questions?
-
-Feel free to drop me an email, but there's already a [StackOverflow](http://stackoverflow.com) tag for [scribe](http://stackoverflow.com/questions/tagged/scribe) you should use. I'm subscribed to it so I'll pick the question immediately.
-
-## Forks
-
-Looking for a scribe variation? check the [Fork List](https://github.com/fernandezpablo85/scribe-java/wiki/Forks)
-
-If you have a useful fork that should be listed there please contact me (see About me).
-
-## About me
-
-[LinkedIn profile](http://www.linkedin.com/in/fernandezpablo85)
-
-Follow me: [@fernandezpablo](http://twitter.com/fernandezpablo)

--- a/changelog.txt
+++ b/changelog.txt
@@ -96,3 +96,8 @@
 [1.3.3]
   * FEATURE: accessToken and requestToken timeouts default to 2 seconds and can be specified.
   * FEATURE: New Apis.
+  
+[1.4.0] Forked by the Scenari Team
+  * FEATURE: wider support of Oauth 2
+  * FEATURE: Several way to specialize a given Oauth 2 implementation in the APIs
+  * FEATURE: Twitter SignIn and Google OAuth 2 Apis

--- a/changelog.txt
+++ b/changelog.txt
@@ -99,5 +99,5 @@
   
 [1.4.0] Forked by the Scenari Team
   * FEATURE: wider support of Oauth 2
-  * FEATURE: Several way to specialize a given Oauth 2 implementation in the APIs
+  * FEATURE: Several ways to specialize a given Oauth 2 implementation in the APIs
   * FEATURE: Twitter SignIn and Google OAuth 2 Apis

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.scribe</groupId>
-  <artifactId>scribe</artifactId>
+  <artifactId>scribe-sc</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.7</version>
-  <name>Scribe OAuth Library</name>
-  <description>The best OAuth library out there</description>
-  <url>http://github.com/fernandezpablo85/scribe-java</url>
+  <version>1.4.0</version>
+  <name>Scribe OAuth Library - forked by the Scenari team</name>
+  <description>The best OAuth library out there. Forked by the Scenari team.</description>
+  <url>http://github.com/scenari/scribe-java.git</url>
 
   <parent>
     <groupId>org.sonatype.oss</groupId>
@@ -36,9 +36,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:http://github.com/fernandezpablo85/scribe-java.git</connection>
-    <developerConnection>scm:http://github.com/fernandezpablo85/scribe-java.git</developerConnection>
-    <url>http://github.com/fernandezpablo85/scribe-java.git</url>
+    <connection>scm:http://github.com/scenari/scribe-java.git</connection>
+    <developerConnection>scm:http://github.com/scenari/scribe-java.git</developerConnection>
+    <url>http://github.com/scenari/scribe-java.git</url>
   </scm>
 
   <distributionManagement>
@@ -161,6 +161,10 @@
                     </goals>
                 </execution>
             </executions>
+        </plugin>
+        <plugin>
+        	<groupId>org.scribe</groupId>
+        	<artifactId>scribe</artifactId>
         </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/scribe/builder/api/DefaultApi20.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi20.java
@@ -66,5 +66,31 @@ public abstract class DefaultApi20 implements Api
   {
     return new OAuth20ServiceImpl(this, config);
   }
+  
+  /**
+   * Returns the type of authentication (plain in form or QueryString or Basic in Header)
+   * Default is QueryString for backward compatibility
+   */
+  public ParameterType getClientAuthenticationType(){
+	  return ParameterType.QueryString;
+  }
+
+  /**
+   * Returns the type of paramters (form, QueryString or Header)
+   * Default is QueryString for backward compatibility
+   */
+  public ParameterType getParameterType() {
+	  return ParameterType.QueryString;
+  }
+
+  /**
+   * Allows APIs to handle the request for free param injection
+   * @param the request ready to be sent by the service
+   * @return the request to be sent by the service
+   */
+  public OAuthRequest handleRequest(OAuthRequest request) {
+	  return request;
+  }
+	
 
 }

--- a/src/main/java/org/scribe/builder/api/DefaultApi20.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi20.java
@@ -96,7 +96,7 @@ public abstract class DefaultApi20 implements Api
    * Allow APIs to hack OAuth2 standard (usefull for facebook wich does not respect the standard
    * @return QueryString => the access token is send as a QueryString in the URL
    */
-  public String getSignatureType()
+  public SignatureType getSignatureType()
   {
     return null;
   }

--- a/src/main/java/org/scribe/builder/api/DefaultApi20.java
+++ b/src/main/java/org/scribe/builder/api/DefaultApi20.java
@@ -76,7 +76,7 @@ public abstract class DefaultApi20 implements Api
   }
 
   /**
-   * Returns the type of paramters (form, QueryString or Header)
+   * Returns the type of parameters (form, QueryString or Header)
    * Default is QueryString for backward compatibility
    */
   public ParameterType getParameterType() {
@@ -90,6 +90,15 @@ public abstract class DefaultApi20 implements Api
    */
   public OAuthRequest handleRequest(OAuthRequest request) {
 	  return request;
+  }
+
+  /**
+   * Allow APIs to hack OAuth2 standard (usefull for facebook wich does not respect the standard
+   * @return QueryString => the access token is send as a QueryString in the URL
+   */
+  public String getSignatureType()
+  {
+    return null;
   }
 	
 

--- a/src/main/java/org/scribe/builder/api/FacebookApi.java
+++ b/src/main/java/org/scribe/builder/api/FacebookApi.java
@@ -1,12 +1,12 @@
 package org.scribe.builder.api;
 
 import org.scribe.model.*;
-
 import org.scribe.utils.*;
 
 public class FacebookApi extends DefaultApi20
 {
   private static final String AUTHORIZE_URL = "https://www.facebook.com/v2.0/dialog/oauth?client_id=%s&redirect_uri=%s";
+
   private static final String SCOPED_AUTHORIZE_URL = AUTHORIZE_URL + "&scope=%s";
 
   @Override
@@ -21,13 +21,20 @@ public class FacebookApi extends DefaultApi20
     Preconditions.checkValidUrl(config.getCallback(), "Must provide a valid url as callback. Facebook does not support OOB");
 
     // Append scope if present
-    if(config.hasScope())
+    if (config.hasScope())
     {
-     return String.format(SCOPED_AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()), OAuthEncoder.encode(config.getScope()));
+      return String.format(SCOPED_AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()), OAuthEncoder.encode(config.getScope()));
     }
     else
     {
       return String.format(AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
     }
   }
+
+  @Override
+  public SignatureType getSignatureType()
+  {
+    return SignatureType.QueryString;
+  }
+
 }

--- a/src/main/java/org/scribe/builder/api/GoogleApi.java
+++ b/src/main/java/org/scribe/builder/api/GoogleApi.java
@@ -1,38 +1,61 @@
 package org.scribe.builder.api;
 
-import org.scribe.model.*;
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.ParameterType;
+import org.scribe.model.Verb;
+import org.scribe.utils.OAuthEncoder;
+import org.scribe.utils.Preconditions;
 
-public class GoogleApi extends DefaultApi10a
+public class GoogleApi extends DefaultApi20
 {
-  private static final String AUTHORIZATION_URL = "https://www.google.com/accounts/OAuthAuthorizeToken?oauth_token=%s";
-  
+  public static final String USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+  protected static final String ACCESS_URL = "https://accounts.google.com/o/oauth2/token";
+
+  protected static final String AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=%s&redirect_uri=%s";
+
+  protected static final String SCOPED_AUTHORIZE_URL = AUTHORIZE_URL + "&scope=%s";
+
   @Override
   public String getAccessTokenEndpoint()
   {
-    return "https://www.google.com/accounts/OAuthGetAccessToken"; 
+    return ACCESS_URL;
   }
 
   @Override
-  public String getRequestTokenEndpoint()
+  public String getAuthorizationUrl(OAuthConfig config)
   {
-    return "https://www.google.com/accounts/OAuthGetRequestToken";
+    Preconditions.checkValidUrl(config.getCallback(), "Must provide a valid url as callback.");
+    // Append scope if present
+    if (config.hasScope())
+      return String.format(SCOPED_AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()), OAuthEncoder.encode(config.getScope()));
+    else
+      return String.format(AUTHORIZE_URL, config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
   }
 
   @Override
   public Verb getAccessTokenVerb()
   {
-    return Verb.GET;
+    return Verb.POST;
   }
 
   @Override
-  public Verb getRequestTokenVerb()
+  public ParameterType getClientAuthenticationType()
   {
-    return Verb.GET;
+    return ParameterType.PostForm;
   }
-  
+
   @Override
-  public String getAuthorizationUrl(Token requestToken)
+  public ParameterType getParameterType()
   {
-    return String.format(AUTHORIZATION_URL, requestToken.getToken());
+    return ParameterType.PostForm;
+  }
+
+  @Override
+  public AccessTokenExtractor getAccessTokenExtractor()
+  {
+    return new JsonTokenExtractor();
   }
 }

--- a/src/main/java/org/scribe/builder/api/TwitterSignInApi.java
+++ b/src/main/java/org/scribe/builder/api/TwitterSignInApi.java
@@ -1,0 +1,14 @@
+package org.scribe.builder.api;
+
+import org.scribe.model.Token;
+import org.scribe.builder.api.TwitterApi;
+
+
+public class TwitterSignInApi extends TwitterApi {
+	private static final String AUTHORIZE_URL = "https://api.twitter.com/oauth/authenticate?oauth_token=%s";
+
+	@Override
+	public String getAuthorizationUrl(Token requestToken) {
+		return String.format(AUTHORIZE_URL, requestToken.getToken());
+	}
+}

--- a/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
+++ b/src/main/java/org/scribe/extractors/JsonTokenExtractor.java
@@ -8,15 +8,18 @@ import org.scribe.utils.*;
 
 public class JsonTokenExtractor implements AccessTokenExtractor
 {
-  private Pattern accessTokenPattern = Pattern.compile("\"access_token\":\\s*\"(\\S*?)\"");
+  private Pattern accessTokenPattern = Pattern.compile("\"access_token\"\\s*:\\s*\"(\\S*?)\"");
+  private Pattern tokenTypePattern = Pattern.compile("\"token_type\"\\s*:\\s*\"(\\S*?)\"");
 
   public Token extract(String response)
   {
     Preconditions.checkEmptyString(response, "Cannot extract a token from a null or empty String");
-    Matcher matcher = accessTokenPattern.matcher(response);
-    if(matcher.find())
+    Matcher matcherAccessToken = accessTokenPattern.matcher(response);
+    Matcher matcherTokenType = tokenTypePattern.matcher(response);
+    if(matcherAccessToken.find())
     {
-      return new Token(matcher.group(1), "", response);
+      if(matcherTokenType.find()) return new Token(matcherAccessToken.group(1), matcherTokenType.group(1), response);
+      else return new Token(matcherAccessToken.group(1), "", response);
     }
     else
     {

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -33,5 +33,7 @@ public class OAuthConstants
   public static final String CLIENT_SECRET = "client_secret";
   public static final String REDIRECT_URI = "redirect_uri";
   public static final String CODE = "code";
+  public static final String GRANT_TYPE = "grant_type";
+  public static final String AUTHORIZATION_CODE = "authorization_code";
 
 }

--- a/src/main/java/org/scribe/model/OAuthConstants.java
+++ b/src/main/java/org/scribe/model/OAuthConstants.java
@@ -35,5 +35,7 @@ public class OAuthConstants
   public static final String CODE = "code";
   public static final String GRANT_TYPE = "grant_type";
   public static final String AUTHORIZATION_CODE = "authorization_code";
+  public static final String BEARER = "Bearer";
+
 
 }

--- a/src/main/java/org/scribe/model/ParameterType.java
+++ b/src/main/java/org/scribe/model/ParameterType.java
@@ -1,0 +1,8 @@
+package org.scribe.model;
+
+public enum ParameterType
+{
+  Header,
+  QueryString,
+  PostForm
+}

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -9,10 +9,11 @@ import org.scribe.services.Base64Encoder;
 public class OAuth20ServiceImpl implements OAuthService
 {
   private static final String VERSION = "2.0";
-  
+
   private final DefaultApi20 api;
+
   private final OAuthConfig config;
-  
+
   /**
    * Default constructor
    * 
@@ -30,56 +31,60 @@ public class OAuth20ServiceImpl implements OAuthService
    */
   public Token getAccessToken(Token requestToken, Verifier verifier)
   {
-	Verb verb = api.getAccessTokenVerb();
-	OAuthRequest request = new OAuthRequest(verb, api.getAccessTokenEndpoint());
-	Response response;
-	switch (api.getClientAuthenticationType()) {
-	case Header :
-		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append("Basic ");
-		stringBuilder.append(Base64Encoder.getInstance().encode((config.getApiKey() + ":" + config.getApiSecret()).getBytes(Charset.forName("UTF-8"))));
-		request.addHeader("Authorization", stringBuilder.toString());
-		break;
-	
-	case PostForm :
-		if(verb!=Verb.POST && verb!=Verb.PUT) throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
-		request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-		request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-		break;
-		
-	case QueryString :
-		request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-		request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-		break;
-	}
-	
-	switch (api.getParameterType()) {
-	case Header :
-		request.addHeader(OAuthConstants.CLIENT_ID, config.getApiKey());
-		request.addHeader(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-		request.addHeader(OAuthConstants.CODE, verifier.getValue());
-		request.addHeader(OAuthConstants.REDIRECT_URI, config.getCallback());
-		if (config.hasScope()) request.addHeader(OAuthConstants.SCOPE, config.getScope());
-		break;
-	
-	case PostForm :
-		if(verb!=Verb.POST && verb!=Verb.PUT) throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
-		request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
-		request.addBodyParameter(OAuthConstants.CODE, verifier.getValue());
-		request.addBodyParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
-		request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-		if (config.hasScope()) request.addBodyParameter(OAuthConstants.SCOPE, config.getScope());
-		break;
-		
-	case QueryString :
-		request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-		request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-		request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
-		request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
-		if (config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
-		break;
-	}
-	response = api.handleRequest(request).send();
+    Verb verb = api.getAccessTokenVerb();
+    OAuthRequest request = new OAuthRequest(verb, api.getAccessTokenEndpoint());
+    Response response;
+    switch (api.getClientAuthenticationType())
+    {
+    case Header:
+      StringBuilder stringBuilder = new StringBuilder();
+      stringBuilder.append("Basic ");
+      stringBuilder.append(Base64Encoder.getInstance().encode((config.getApiKey() + ":" + config.getApiSecret()).getBytes(Charset.forName("UTF-8"))));
+      request.addHeader("Authorization", stringBuilder.toString());
+      break;
+
+    case PostForm:
+      if (verb != Verb.POST && verb != Verb.PUT)
+        throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
+      request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+      break;
+
+    case QueryString:
+      request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+      request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+      break;
+    }
+
+    switch (api.getParameterType())
+    {
+    case Header:
+      request.addHeader(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
+      request.addHeader(OAuthConstants.CODE, verifier.getValue());
+      request.addHeader(OAuthConstants.REDIRECT_URI, config.getCallback());
+      if (config.hasScope())
+        request.addHeader(OAuthConstants.SCOPE, config.getScope());
+      break;
+
+    case PostForm:
+      if (verb != Verb.POST && verb != Verb.PUT)
+        throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
+      request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
+      request.addBodyParameter(OAuthConstants.CODE, verifier.getValue());
+      request.addBodyParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+      if (config.hasScope())
+        request.addBodyParameter(OAuthConstants.SCOPE, config.getScope());
+      break;
+
+    case QueryString:
+      request.addQuerystringParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
+      request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
+      request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+      if (config.hasScope())
+        request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
+      break;
+    }
+    response = api.handleRequest(request).send();
     return api.getAccessTokenExtractor().extract(response.getBody());
   }
 
@@ -104,7 +109,22 @@ public class OAuth20ServiceImpl implements OAuthService
    */
   public void signRequest(Token accessToken, OAuthRequest request)
   {
-    request.addQuerystringParameter(OAuthConstants.ACCESS_TOKEN, accessToken.getToken());
+    // Not Oauth2 but usefull for some pseudo-oauth2 providers
+    if (config.getSignatureType().equals(SignatureType.QueryString)|| api.getSignatureType() == SignatureType.QueryString)
+      request.addQuerystringParameter(OAuthConstants.ACCESS_TOKEN, accessToken.getToken());
+    else
+    {
+      // With Oauth 2, the empty secret field is used to store the token type
+      if (accessToken.getSecret().equals(OAuthConstants.BEARER))
+      {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("Bearer ");
+        stringBuilder.append(accessToken.getToken());
+        request.addHeader("Authorization", stringBuilder.toString());
+      }
+      else
+        throw new UnsupportedOperationException("Unsupported OAuth2 access token type");
+    }
   }
 
   /**

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -1,5 +1,7 @@
 package org.scribe.oauth;
 
+import java.nio.charset.Charset;
+
 import org.scribe.builder.api.*;
 import org.scribe.model.*;
 import org.scribe.services.Base64Encoder;
@@ -34,7 +36,7 @@ public class OAuth20ServiceImpl implements OAuthService
 	if (verb == Verb.POST || verb == Verb.PUT) {
 		StringBuilder stringBuilder = new StringBuilder();
 		stringBuilder.append("Basic ");
-		stringBuilder.append(Base64Encoder.getInstance().encode((config.getApiKey() + ":" + config.getApiSecret()).getBytes()));
+		stringBuilder.append(Base64Encoder.getInstance().encode((config.getApiKey() + ":" + config.getApiSecret()).getBytes(Charset.forName("UTF-8"))));
 		request.addHeader("Authorization", stringBuilder.toString());
 
 		request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -33,26 +33,53 @@ public class OAuth20ServiceImpl implements OAuthService
 	Verb verb = api.getAccessTokenVerb();
 	OAuthRequest request = new OAuthRequest(verb, api.getAccessTokenEndpoint());
 	Response response;
-	if (verb == Verb.POST || verb == Verb.PUT) {
+	switch (api.getClientAuthenticationType()) {
+	case Header :
 		StringBuilder stringBuilder = new StringBuilder();
 		stringBuilder.append("Basic ");
 		stringBuilder.append(Base64Encoder.getInstance().encode((config.getApiKey() + ":" + config.getApiSecret()).getBytes(Charset.forName("UTF-8"))));
 		request.addHeader("Authorization", stringBuilder.toString());
-
+		break;
+	
+	case PostForm :
+		if(verb!=Verb.POST && verb!=Verb.PUT) throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
+		request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+		request.addBodyParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+		break;
+		
+	case QueryString :
+		request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+		request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+		break;
+	}
+	
+	switch (api.getParameterType()) {
+	case Header :
+		request.addHeader(OAuthConstants.CLIENT_ID, config.getApiKey());
+		request.addHeader(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+		request.addHeader(OAuthConstants.CODE, verifier.getValue());
+		request.addHeader(OAuthConstants.REDIRECT_URI, config.getCallback());
+		if (config.hasScope()) request.addHeader(OAuthConstants.SCOPE, config.getScope());
+		break;
+	
+	case PostForm :
+		if(verb!=Verb.POST && verb!=Verb.PUT) throw new IllegalArgumentException("Impossible to set parameter in a form with an other HTTP method than POST or PUT");
 		request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
 		request.addBodyParameter(OAuthConstants.CODE, verifier.getValue());
 		request.addBodyParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
 		request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
 		if (config.hasScope()) request.addBodyParameter(OAuthConstants.SCOPE, config.getScope());
-		response = request.send();
-	} else {
+		break;
+		
+	case QueryString :
 		request.addQuerystringParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
 		request.addQuerystringParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
 		request.addQuerystringParameter(OAuthConstants.CODE, verifier.getValue());
 		request.addQuerystringParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
 		if (config.hasScope()) request.addQuerystringParameter(OAuthConstants.SCOPE, config.getScope());
-		response = request.send();
+		break;
 	}
+	response = api.handleRequest(request).send();
     return api.getAccessTokenExtractor().extract(response.getBody());
   }
 

--- a/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
+++ b/src/main/java/org/scribe/oauth/OAuth20ServiceImpl.java
@@ -40,6 +40,7 @@ public class OAuth20ServiceImpl implements OAuthService
 		request.addBodyParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
 		request.addBodyParameter(OAuthConstants.CODE, verifier.getValue());
 		request.addBodyParameter(OAuthConstants.REDIRECT_URI, config.getCallback());
+		request.addBodyParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
 		if (config.hasScope()) request.addBodyParameter(OAuthConstants.SCOPE, config.getScope());
 		response = request.send();
 	} else {


### PR DESCRIPTION
The 4.1.3 section of the rfc6749 specifies that the grant_type, code, redirect_uri and client_id parameters must be sent using the "application/x-www-form-urlencoded" format which implies the use of a url-encoded form in the body of the request for the POST and PUT methods.