### PR TITLE
change getStream to be public

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/Response.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/Response.java
@@ -68,7 +68,7 @@ public class Response {
      *
      * @return input stream / error stream
      */
-    protected InputStream getStream() {
+    public InputStream getStream() {
         return stream;
     }
 


### PR DESCRIPTION
See: Support streamed responses (e.g. twitter streaming endpoints) #582 

After trying to make things work with protected, I agree your original intuition for making it public in #582 is the right choice.