### PR TITLE
Make API and Core proper OSGi artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
             </plugin>
         </plugins>
     </build>
-  
+
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>
@@ -224,8 +224,30 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>maven-bundle-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>bundle-manifest</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>manifest</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
-</project>  
+</project>


### PR DESCRIPTION
Adding the Felix Maven bundle plugin allows the resulting artifacts to be used as-is in an OSGi environment.