### PR TITLE
Fixed password grant type (tested with Salesforce)

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
@@ -72,6 +72,10 @@ public class OAuthConfig {
         return grantType != null;
     }
 
+    public boolean hasClientCredentials() {
+        return apiKey != null && apiSecret != null;
+    }
+
     public Integer getConnectTimeout() {
         return connectTimeout;
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -172,15 +172,17 @@ public class OAuth20Service extends OAuthService {
 
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.PASSWORD);
 
-        request.addParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-        request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
-        request.addHeader(OAuthConstants.HEADER, OAuthConstants.BASIC + " "
-                + Base64Encoder.getInstance().encode(
-                        String.format("%s:%s", config.getApiKey(), config.getApiSecret()).getBytes(
-                        Charset.forName("UTF-8")
-                )
-                )
-        );
+        if (config.hasClientCredentials()) {
+            request.addParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+            request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+            request.addHeader(OAuthConstants.HEADER, OAuthConstants.BASIC + " "
+                    + Base64Encoder.getInstance().encode(
+                            String.format("%s:%s", config.getApiKey(), config.getApiSecret()).getBytes(
+                            Charset.forName("UTF-8")
+                    )
+                    )
+            );
+        }
 
         return request;
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -172,6 +172,8 @@ public class OAuth20Service extends OAuthService {
 
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.PASSWORD);
 
+        request.addParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
+        request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
         request.addHeader(OAuthConstants.HEADER, OAuthConstants.BASIC + " "
                 + Base64Encoder.getInstance().encode(
                         String.format("%s:%s", config.getApiKey(), config.getApiSecret()).getBytes(


### PR DESCRIPTION
Previous password grant type didn't work for my integration with salesforce. Adding those parameters resolved this.