### PR TITLE
Add constructor to avoid indirect ning/AHC class dependencies

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
@@ -53,6 +53,22 @@ public class OAuthConfig {
         this.ahcAsyncHttpClientConfig = ahcAsyncHttpClientConfig;
     }
 
+    public OAuthConfig(String apiKey, String apiSecret, String callback, SignatureType signatureType, String scope,
+            OutputStream debugStream, String state, String responseType, String userAgent, Integer connectTimeout,
+            Integer readTimeout) {
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
+        this.callback = callback;
+        this.signatureType = signatureType;
+        this.scope = scope;
+        this.debugStream = debugStream;
+        this.state = state;
+        this.responseType = responseType;
+        this.userAgent = userAgent;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+
     public String getApiKey() {
         return apiKey;
     }


### PR DESCRIPTION
Fix for GitHub issue #668. Add a constructor without references to ning/AHC classes to remove indirect dependencies.