### PR TITLE
Fixed shouldExtractStandardHeader to not rely on the unguaranteed order

### DIFF
--- a/scribejava-core/src/test/java/com/github/scribejava/core/extractors/HeaderExtractorTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/extractors/HeaderExtractorTest.java
@@ -31,7 +31,7 @@ public class HeaderExtractorTest {
         final String key = "oauth_consumer_key=\"AS%23%24%5E%2A%40%26\"";
         final String timestamp = "oauth_timestamp=\"123456\"";
 
-        assertTrue(header.contains(oauth));
+        assertTrue(header.startsWith(oauth));
         assertTrue(header.contains(callback));
         assertTrue(header.contains(signature));
         assertTrue(header.contains(key));

--- a/scribejava-core/src/test/java/com/github/scribejava/core/extractors/HeaderExtractorTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/extractors/HeaderExtractorTest.java
@@ -1,6 +1,7 @@
 package com.github.scribejava.core.extractors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import com.github.scribejava.core.exceptions.OAuthParametersMissingException;
@@ -24,16 +25,24 @@ public class HeaderExtractorTest {
     @Test
     public void shouldExtractStandardHeader() {
         final String header = extractor.extract(request);
-        try {
-            assertEquals("OAuth oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\", "
-                    + "oauth_signature=\"OAuth-Signature\", oauth_consumer_key=\"AS%23%24%5E%2A%40%26\", "
-                    + "oauth_timestamp=\"123456\"", header);
-        } catch (AssertionError ae) {
-            //maybe this is OpenJDK 8? Different order of elements in HashMap while iterating'em.
-            assertEquals("OAuth oauth_signature=\"OAuth-Signature\", "
-                    + "oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\", "
-                    + "oauth_consumer_key=\"AS%23%24%5E%2A%40%26\", oauth_timestamp=\"123456\"", header);
-        }
+        final String oauth = "OAuth ";
+        final String callback = "oauth_callback=\"http%3A%2F%2Fexample%2Fcallback\"";
+        final String signature = "oauth_signature=\"OAuth-Signature\"";
+        final String key = "oauth_consumer_key=\"AS%23%24%5E%2A%40%26\"";
+        final String timestamp = "oauth_timestamp=\"123456\"";
+
+        assertTrue(header.contains(oauth));
+        assertTrue(header.contains(callback));
+        assertTrue(header.contains(signature));
+        assertTrue(header.contains(key));
+        assertTrue(header.contains(timestamp));
+        // Assert that header only contains the checked elements above and nothing else
+        assertEquals(", , , ",
+               header.replaceFirst(oauth, "")
+                     .replaceFirst(callback, "")
+                     .replaceFirst(signature, "")
+                     .replaceFirst(key, "")
+                     .replaceFirst(timestamp, ""));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The test assumes that the HashMap is iterated in a certain order.

The fix simply asserts that the required elements are contained in the header string in any order, insted of assuming a particular order.
It then asserts that only the 4 checked parts are in the string and are separated by comma, as the original test checks.
This way of checking makes the test robust to changes in the underlying JVM's implementation of HashMap.