### PR TITLE
fixed MapUtils test to not rely on HashMap's internal ordering

### DIFF
--- a/scribejava-core/src/test/java/com/github/scribejava/core/utils/MapUtilsTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/utils/MapUtilsTest.java
@@ -1,5 +1,6 @@
 package com.github.scribejava.core.utils;
 
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
@@ -9,7 +10,7 @@ public class MapUtilsTest {
 
     @Test
     public void shouldPrettyPrintMap() {
-        final Map<Integer, String> map = new HashMap<>();
+        final Map<Integer, String> map = new LinkedHashMap<>();
         map.put(1, "one");
         map.put(2, "two");
         map.put(3, "three");


### PR DESCRIPTION
MapUtils seems it should work for any instance of Map but this test is assuming a certain ordering from the HashMap; HashMap's spec does not guarantee any order.

Changed to LinkedHashMap, which guarantees the order; the pretty printing should work for any kind of map.