### PR TITLE
New API for IBM Connections Cloud, extends scribejava-apis

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/ConnectionsCloudApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/ConnectionsCloudApi.java
@@ -1,0 +1,63 @@
+package com.github.scribejava.apis;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.extractors.OAuth2AccessTokenExtractor;
+import com.github.scribejava.core.extractors.TokenExtractor;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.Verb;
+
+public class ConnectionsCloudApi extends DefaultApi20 {
+
+	public enum CC_DATACENTER {
+		NA,
+		CE,
+		AP
+	}
+
+	private String datacenterUrl = null;
+	
+    protected ConnectionsCloudApi(CC_DATACENTER datacenter) {
+    	switch (datacenter) {
+		case CE:
+			this.datacenterUrl = "https://apps.ce.collabserv.com";
+			break;
+		case NA:
+			this.datacenterUrl = "https://apps.na.collabserv.com";
+			break;
+		case AP:
+			this.datacenterUrl = "https://apps.ap.collabserv.com";
+			break;
+		default:
+			throw new IllegalArgumentException("Datacenter : " + datacenter + " is not supported");
+		}
+    	 
+    }
+
+    private static class InstanceHolder {
+        private static final ConnectionsCloudApi INSTANCE = new ConnectionsCloudApi(CC_DATACENTER.CE);
+    }
+
+    public static ConnectionsCloudApi instance(CC_DATACENTER datacenter) {
+        return InstanceHolder.INSTANCE;
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.POST;
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return datacenterUrl + "/manage/oauth2/token";
+    }
+
+    @Override
+    protected String getAuthorizationBaseUrl() {
+        return datacenterUrl + "/manage/oauth2/authorize";
+    }
+
+    @Override
+    public TokenExtractor<OAuth2AccessToken> getAccessTokenExtractor() {
+        return OAuth2AccessTokenExtractor.instance();
+    }
+}

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/ConnectionsCloudApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/ConnectionsCloudApi.java
@@ -1,14 +1,28 @@
 package com.github.scribejava.apis;
 
+import java.security.InvalidParameterException;
+
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.extractors.OAuth2AccessTokenExtractor;
 import com.github.scribejava.core.extractors.TokenExtractor;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.model.Verb;
 
+/**
+ * ConnectionsCloudApi supports OAuth2 endpoint for IBM Connections Cloud.
+ * 
+ * as IBM CC has multiple datacenter and multiple endpoints an enum object is provided 
+ * with the listing of allowable datacenters.
+ * 
+ * This API is based on BitBuckets Oauth2 API and simplifies usage of ConnectionsCloud
+ * services.
+ *  
+ * @author daniele.vistalli@factor-y.com
+ *
+ */
 public class ConnectionsCloudApi extends DefaultApi20 {
 
-	public enum CC_DATACENTER {
+	public enum CC_Datacenter {
 		NA,
 		CE,
 		AP
@@ -16,7 +30,7 @@ public class ConnectionsCloudApi extends DefaultApi20 {
 
 	private String datacenterUrl = null;
 	
-    protected ConnectionsCloudApi(CC_DATACENTER datacenter) {
+    protected ConnectionsCloudApi(CC_Datacenter datacenter) {
     	switch (datacenter) {
 		case CE:
 			this.datacenterUrl = "https://apps.ce.collabserv.com";
@@ -33,12 +47,27 @@ public class ConnectionsCloudApi extends DefaultApi20 {
     	 
     }
 
-    private static class InstanceHolder {
-        private static final ConnectionsCloudApi INSTANCE = new ConnectionsCloudApi(CC_DATACENTER.CE);
+    private static class InstanceHolderNA {
+        private static final ConnectionsCloudApi INSTANCE = new ConnectionsCloudApi(CC_Datacenter.NA);
+    }
+    private static class InstanceHolderCE {
+        private static final ConnectionsCloudApi INSTANCE = new ConnectionsCloudApi(CC_Datacenter.CE);
+    }
+    private static class InstanceHolderAP {
+        private static final ConnectionsCloudApi INSTANCE = new ConnectionsCloudApi(CC_Datacenter.AP);
     }
 
-    public static ConnectionsCloudApi instance(CC_DATACENTER datacenter) {
-        return InstanceHolder.INSTANCE;
+    public static ConnectionsCloudApi instance(CC_Datacenter datacenter) {
+    	switch (datacenter) {
+		case NA:
+			return InstanceHolderNA.INSTANCE;
+		case CE:
+			return InstanceHolderCE.INSTANCE;
+		case AP:
+			return InstanceHolderAP.INSTANCE;
+		default:
+			throw new InvalidParameterException("Datacenter name is not allowed: " + datacenter);
+		}
     }
 
     @Override


### PR DESCRIPTION
I learned about scribejava and immediately loved it. So clear, so smart I couldn't avoid moving my apps to it.

As I work with IBM Connections Cloud services I created a new API object that covers integration needs for Connections Cloud.

It would be loverly if this can be integrated in the official repository.

If you've any request just let me know.