### PR TITLE
Manage error response for token request

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/exceptions/OAuthRequestException.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/exceptions/OAuthRequestException.java
@@ -1,0 +1,17 @@
+package com.github.scribejava.core.exceptions;
+
+import com.github.scribejava.core.model.OAuth2ErrorResponse;
+
+public class OAuthRequestException extends OAuthException {
+
+    private final OAuth2ErrorResponse error;
+
+    public OAuthRequestException(String message, OAuth2ErrorResponse error) {
+        super(message);
+        this.error = error;
+    }
+
+    public OAuth2ErrorResponse getError() {
+        return error;
+    }
+}

--- a/scribejava-core/src/main/java/com/github/scribejava/core/extractors/AbstractOAuth1TokenExtractor.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/extractors/AbstractOAuth1TokenExtractor.java
@@ -1,9 +1,11 @@
 package com.github.scribejava.core.extractors;
 
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth1Token;
+import com.github.scribejava.core.model.Response;
 import com.github.scribejava.core.utils.OAuthEncoder;
 import com.github.scribejava.core.utils.Preconditions;
 
@@ -23,12 +25,13 @@ public abstract class AbstractOAuth1TokenExtractor<T extends OAuth1Token> implem
      * {@inheritDoc}
      */
     @Override
-    public T extract(String response) {
-        Preconditions.checkEmptyString(response,
+    public T extract(Response response) throws IOException {
+        final String body = response.getBody();
+        Preconditions.checkEmptyString(body,
                 "Response body is incorrect. Can't extract a token from an empty string");
-        final String token = extract(response, Pattern.compile(OAUTH_TOKEN_REGEXP));
-        final String secret = extract(response, Pattern.compile(OAUTH_TOKEN_SECRET_REGEXP));
-        return createToken(token, secret, response);
+        final String token = extract(body, Pattern.compile(OAUTH_TOKEN_REGEXP));
+        final String secret = extract(body, Pattern.compile(OAUTH_TOKEN_SECRET_REGEXP));
+        return createToken(token, secret, body);
     }
 
     private String extract(String response, Pattern p) {

--- a/scribejava-core/src/main/java/com/github/scribejava/core/extractors/OAuth2AccessTokenExtractor.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/extractors/OAuth2AccessTokenExtractor.java
@@ -1,9 +1,11 @@
 package com.github.scribejava.core.extractors;
 
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.Response;
 import com.github.scribejava.core.utils.OAuthEncoder;
 import com.github.scribejava.core.utils.Preconditions;
 
@@ -34,23 +36,24 @@ public class OAuth2AccessTokenExtractor implements TokenExtractor<OAuth2AccessTo
      * {@inheritDoc}
      */
     @Override
-    public OAuth2AccessToken extract(String response) {
-        Preconditions.checkEmptyString(response,
+    public OAuth2AccessToken extract(Response response) throws IOException {
+        final String body = response.getBody();
+        Preconditions.checkEmptyString(body,
                 "Response body is incorrect. Can't extract a token from an empty string");
 
-        final String accessToken = extractParameter(response, ACCESS_TOKEN_REGEX, true);
-        final String tokenType = extractParameter(response, TOKEN_TYPE_REGEX, false);
-        final String expiresInString = extractParameter(response, EXPIRES_IN_REGEX, false);
+        final String accessToken = extractParameter(body, ACCESS_TOKEN_REGEX, true);
+        final String tokenType = extractParameter(body, TOKEN_TYPE_REGEX, false);
+        final String expiresInString = extractParameter(body, EXPIRES_IN_REGEX, false);
         Integer expiresIn;
         try {
             expiresIn = expiresInString == null ? null : Integer.valueOf(expiresInString);
         } catch (NumberFormatException nfe) {
             expiresIn = null;
         }
-        final String refreshToken = extractParameter(response, REFRESH_TOKEN_REGEX, false);
-        final String scope = extractParameter(response, SCOPE_REGEX, false);
+        final String refreshToken = extractParameter(body, REFRESH_TOKEN_REGEX, false);
+        final String scope = extractParameter(body, SCOPE_REGEX, false);
 
-        return new OAuth2AccessToken(accessToken, tokenType, expiresIn, refreshToken, scope, response);
+        return new OAuth2AccessToken(accessToken, tokenType, expiresIn, refreshToken, scope, body);
     }
 
     private static String extractParameter(String response, String regex, boolean required) throws OAuthException {

--- a/scribejava-core/src/main/java/com/github/scribejava/core/extractors/TokenExtractor.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/extractors/TokenExtractor.java
@@ -1,6 +1,10 @@
 package com.github.scribejava.core.extractors;
 
+import com.github.scribejava.core.exceptions.OAuthException;
+import com.github.scribejava.core.model.Response;
 import com.github.scribejava.core.model.Token;
+
+import java.io.IOException;
 
 /**
  * Simple command object that extracts a concrete {@link Token} from a String
@@ -14,5 +18,5 @@ public interface TokenExtractor<T extends Token> {
      * @param response the contents of the response
      * @return OAuth access token
      */
-    T extract(String response);
+    T extract(Response response) throws IOException, OAuthException;
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuth2ErrorResponse.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuth2ErrorResponse.java
@@ -1,0 +1,51 @@
+package com.github.scribejava.core.model;
+
+import com.github.scribejava.core.exceptions.OAuthException;
+
+import java.net.URI;
+
+/**
+ * Representing <a href="https://tools.ietf.org/html/rfc6749#section-5.2">"5.2. Error Response"</a>
+ */
+public class OAuth2ErrorResponse extends OAuthException {
+
+    public enum OAuthError {
+        invalid_request, invalid_client, invalid_grant, unauthorized_client, unsupported_grant_type, invalid_scope
+    }
+
+    private final OAuthError error;
+    private final String errorDescription;
+    private final URI errorUri;
+    private final String rawResponse;
+
+    public OAuth2ErrorResponse(OAuthError error, String errorDescription, URI errorUri, String rawResponse) {
+        super(generateMessage(error, errorDescription, errorUri, rawResponse));
+        if (error == null) {
+            throw new IllegalArgumentException("error must not be null");
+        }
+        this.error = error;
+        this.errorDescription = errorDescription;
+        this.errorUri = errorUri;
+        this.rawResponse = rawResponse;
+    }
+
+    private static String generateMessage(OAuthError error, String errorDescription, URI errorUri, String rawResponse) {
+        return rawResponse;
+    }
+
+    public OAuthError getError() {
+        return error;
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
+    public URI getErrorUri() {
+        return errorUri;
+    }
+
+    public String getRawResponse() {
+        return rawResponse;
+    }
+}

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
@@ -48,7 +48,7 @@ public class OAuth10aService extends OAuthService {
 
         config.log("response status code: " + response.getCode());
         config.log("response body: " + body);
-        return api.getRequestTokenExtractor().extract(body);
+        return api.getRequestTokenExtractor().extract(response);
     }
 
     public final Future<OAuth1RequestToken> getRequestTokenAsync(
@@ -61,7 +61,7 @@ public class OAuth10aService extends OAuthService {
         return request.sendAsync(callback, new OAuthRequestAsync.ResponseConverter<OAuth1RequestToken>() {
             @Override
             public OAuth1RequestToken convert(Response response) throws IOException {
-                return getApi().getRequestTokenExtractor().extract(response.getBody());
+                return getApi().getRequestTokenExtractor().extract(response);
             }
         });
     }
@@ -97,7 +97,7 @@ public class OAuth10aService extends OAuthService {
         final OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint(), this);
         prepareAccessTokenRequest(request, requestToken, oauthVerifier);
         final Response response = request.send();
-        return api.getAccessTokenExtractor().extract(response.getBody());
+        return api.getAccessTokenExtractor().extract(response);
     }
 
     /**
@@ -119,7 +119,7 @@ public class OAuth10aService extends OAuthService {
         return request.sendAsync(callback, new OAuthRequestAsync.ResponseConverter<OAuth1AccessToken>() {
             @Override
             public OAuth1AccessToken convert(Response response) throws IOException {
-                return getApi().getAccessTokenExtractor().extract(response.getBody());
+                return getApi().getAccessTokenExtractor().extract(response);
             }
         });
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -34,7 +34,7 @@ public class OAuth20Service extends OAuthService {
 
     //sync version, protected to facilitate mocking
     protected OAuth2AccessToken sendAccessTokenRequestSync(OAuthRequest request) throws IOException {
-        return api.getAccessTokenExtractor().extract(request.send().getBody());
+        return api.getAccessTokenExtractor().extract(request.send());
     }
 
     //async version, protected to facilitate mocking
@@ -44,7 +44,7 @@ public class OAuth20Service extends OAuthService {
         return request.sendAsync(callback, new OAuthRequestAsync.ResponseConverter<OAuth2AccessToken>() {
             @Override
             public OAuth2AccessToken convert(Response response) throws IOException {
-                return getApi().getAccessTokenExtractor().extract(response.getBody());
+                return getApi().getAccessTokenExtractor().extract(response);
             }
         });
     }

--- a/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth1AccessTokenExtractorTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth1AccessTokenExtractorTest.java
@@ -1,9 +1,14 @@
 package com.github.scribejava.core.extractors;
 
+import com.github.scribejava.core.model.Response;
 import org.junit.Before;
 import org.junit.Test;
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth1Token;
+
+import java.io.IOException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 
 public class OAuth1AccessTokenExtractorTest {
@@ -16,58 +21,63 @@ public class OAuth1AccessTokenExtractorTest {
     }
 
     @Test
-    public void shouldExtractTokenFromOAuthStandardResponse() {
+    public void shouldExtractTokenFromOAuthStandardResponse() throws IOException {
         final String response = "oauth_token=hh5s93j4hdidpola&oauth_token_secret=hdhd0244k9j7ao03";
-        final OAuth1Token extracted = extractor.extract(response);
+        final OAuth1Token extracted = extractor.extract(ok(response));
         assertEquals("hh5s93j4hdidpola", extracted.getToken());
         assertEquals("hdhd0244k9j7ao03", extracted.getTokenSecret());
     }
 
     @Test
-    public void shouldExtractTokenFromInvertedOAuthStandardResponse() {
+    public void shouldExtractTokenFromInvertedOAuthStandardResponse() throws IOException {
         final String response = "oauth_token_secret=hh5s93j4hdidpola&oauth_token=hdhd0244k9j7ao03";
-        final OAuth1Token extracted = extractor.extract(response);
+        final OAuth1Token extracted = extractor.extract(ok(response));
         assertEquals("hh5s93j4hdidpola", extracted.getTokenSecret());
         assertEquals("hdhd0244k9j7ao03", extracted.getToken());
     }
 
     @Test
-    public void shouldExtractTokenFromResponseWithCallbackConfirmed() {
+    public void shouldExtractTokenFromResponseWithCallbackConfirmed() throws IOException {
         final String response = "oauth_token=hh5s93j4hdidpola&oauth_token_secret=hdhd0244k9j7ao03"
                 + "&callback_confirmed=true";
-        final OAuth1Token extracted = extractor.extract(response);
+        final OAuth1Token extracted = extractor.extract(ok(response));
         assertEquals("hh5s93j4hdidpola", extracted.getToken());
         assertEquals("hdhd0244k9j7ao03", extracted.getTokenSecret());
     }
 
     @Test
-    public void shouldExtractTokenWithEmptySecret() {
+    public void shouldExtractTokenWithEmptySecret() throws IOException {
         final String response = "oauth_token=hh5s93j4hdidpola&oauth_token_secret=";
-        final OAuth1Token extracted = extractor.extract(response);
+        final OAuth1Token extracted = extractor.extract(ok(response));
         assertEquals("hh5s93j4hdidpola", extracted.getToken());
         assertEquals("", extracted.getTokenSecret());
     }
 
     @Test(expected = OAuthException.class)
-    public void shouldThrowExceptionIfTokenIsAbsent() {
+    public void shouldThrowExceptionIfTokenIsAbsent() throws IOException {
         final String response = "oauth_secret=hh5s93j4hdidpola&callback_confirmed=true";
-        extractor.extract(response);
+        extractor.extract(ok(response));
     }
 
     @Test(expected = OAuthException.class)
-    public void shouldThrowExceptionIfSecretIsAbsent() {
+    public void shouldThrowExceptionIfSecretIsAbsent() throws IOException {
         final String response = "oauth_token=hh5s93j4hdidpola&callback_confirmed=true";
-        extractor.extract(response);
+        extractor.extract(ok(response));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfResponseIsNull() {
-        extractor.extract(null);
+    public void shouldThrowExceptionIfResponseIsNull() throws IOException {
+        extractor.extract(ok(null));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfResponseIsEmptyString() {
+    public void shouldThrowExceptionIfResponseIsEmptyString() throws IOException {
         final String response = "";
-        extractor.extract(response);
+        extractor.extract(ok(response));
+    }
+
+    private static Response ok(String body) {
+        return new Response(200, /* message */ null, /* headers */ Collections.<String, String>emptyMap(),
+                body, /* stream */ null);
     }
 }

--- a/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth2AccessTokenExtractorTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth2AccessTokenExtractorTest.java
@@ -1,9 +1,14 @@
 package com.github.scribejava.core.extractors;
 
+import com.github.scribejava.core.model.Response;
 import org.junit.Before;
 import org.junit.Test;
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+
+import java.io.IOException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 
 public class OAuth2AccessTokenExtractorTest {
@@ -16,29 +21,29 @@ public class OAuth2AccessTokenExtractorTest {
     }
 
     @Test
-    public void shouldExtractTokenFromOAuthStandardResponse() {
+    public void shouldExtractTokenFromOAuthStandardResponse() throws IOException {
         final String response = "access_token=166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159"
                 + "|RsXNdKrpxg8L6QNLWcs2TVTmcaE";
-        final OAuth2AccessToken extracted = extractor.extract(response);
+        final OAuth2AccessToken extracted = extractor.extract(ok(response));
         assertEquals("166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159|RsXNdKrpxg8L6QNLWcs2TVTmcaE",
                 extracted.getAccessToken());
     }
 
     @Test
-    public void shouldExtractTokenFromResponseWithExpiresParam() {
+    public void shouldExtractTokenFromResponseWithExpiresParam() throws IOException {
         final String response = "access_token=166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159"
                 + "|RsXNdKrpxg8L6QNLWcs2TVTmcaE&expires_in=5108";
-        final OAuth2AccessToken extracted = extractor.extract(response);
+        final OAuth2AccessToken extracted = extractor.extract(ok(response));
         assertEquals("166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159|RsXNdKrpxg8L6QNLWcs2TVTmcaE",
                 extracted.getAccessToken());
         assertEquals(Integer.valueOf(5108), extracted.getExpiresIn());
     }
 
     @Test
-    public void shouldExtractTokenFromResponseWithExpiresAndRefreshParam() {
+    public void shouldExtractTokenFromResponseWithExpiresAndRefreshParam() throws IOException {
         final String response = "access_token=166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159"
                 + "|RsXNdKrpxg8L6QNLWcs2TVTmcaE&expires_in=5108&token_type=bearer&refresh_token=166942940015970";
-        final OAuth2AccessToken extracted = extractor.extract(response);
+        final OAuth2AccessToken extracted = extractor.extract(ok(response));
         assertEquals("166942940015970|2.2ltzWXYNDjCtg5ZDVVJJeg__.3600.1295816400-548517159|RsXNdKrpxg8L6QNLWcs2TVTmcaE",
                 extracted.getAccessToken());
         assertEquals(Integer.valueOf(5108), extracted.getExpiresIn());
@@ -47,26 +52,31 @@ public class OAuth2AccessTokenExtractorTest {
     }
 
     @Test
-    public void shouldExtractTokenFromResponseWithManyParameters() {
+    public void shouldExtractTokenFromResponseWithManyParameters() throws IOException {
         final String response = "access_token=foo1234&other_stuff=yeah_we_have_this_too&number=42";
-        final OAuth2AccessToken extracted = extractor.extract(response);
+        final OAuth2AccessToken extracted = extractor.extract(ok(response));
         assertEquals("foo1234", extracted.getAccessToken());
     }
 
     @Test(expected = OAuthException.class)
-    public void shouldThrowExceptionIfTokenIsAbsent() {
+    public void shouldThrowExceptionIfTokenIsAbsent() throws IOException {
         final String response = "&expires=5108";
-        extractor.extract(response);
+        extractor.extract(ok(response));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfResponseIsNull() {
-        extractor.extract(null);
+    public void shouldThrowExceptionIfResponseIsNull() throws IOException {
+        extractor.extract(ok(null));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfResponseIsEmptyString() {
+    public void shouldThrowExceptionIfResponseIsEmptyString() throws IOException {
         final String response = "";
-        extractor.extract(response);
+        extractor.extract(ok(response));
+    }
+
+    private static Response ok(String body) {
+        return new Response(200, /* message */ null, /* headers */ Collections.<String, String>emptyMap(),
+                body, /* stream */ null);
     }
 }

--- a/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth2AccessTokenJsonExtractorTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/extractors/OAuth2AccessTokenJsonExtractorTest.java
@@ -1,8 +1,15 @@
 package com.github.scribejava.core.extractors;
 
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuth2ErrorResponse;
+import com.github.scribejava.core.model.Response;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class OAuth2AccessTokenJsonExtractorTest {
 
@@ -10,18 +17,45 @@ public class OAuth2AccessTokenJsonExtractorTest {
     private final OAuth2AccessTokenJsonExtractor extractor = OAuth2AccessTokenJsonExtractor.instance();
 
     @Test
-    public void shouldParseResponse() {
-        final OAuth2AccessToken token = extractor.extract(RESPONSE);
+    public void shouldParseResponse() throws IOException {
+        final OAuth2AccessToken token = extractor.extract(ok(RESPONSE));
         assertEquals(token.getAccessToken(), "I0122HHJKLEM21F3WLPYHDKGKZULAUO4SGMV3ABKFTDT3T3X");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfForNullParameters() {
-        extractor.extract(null);
+    public void shouldThrowExceptionIfForNullParameters() throws IOException {
+        extractor.extract(ok(null));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfForEmptyStrings() {
-        extractor.extract("");
+    public void shouldThrowExceptionIfForEmptyStrings() throws IOException {
+        extractor.extract(ok(""));
+    }
+
+    @Test
+    public void shouldThrowExceptionIfResponseIsError() throws IOException {
+        final String body = "{" +
+                "\"error_description\":\"unknown, invalid, or expired refresh token\"," +
+                "\"error\":\"invalid_grant\"" +
+                "}";
+        boolean hadException = false;
+        try {
+            extractor.extract(error(body));
+        } catch (OAuth2ErrorResponse oaer) {
+            hadException = true;
+            assertEquals(OAuth2ErrorResponse.OAuthError.invalid_grant, oaer.getError());
+            assertEquals("unknown, invalid, or expired refresh token", oaer.getErrorDescription());
+        }
+        assertTrue(hadException);
+    }
+
+    private static Response ok(String body) {
+        return new Response(200, /* message */ null, /* headers */ Collections.<String, String>emptyMap(),
+                body, /* stream */ null);
+    }
+
+    private static Response error(String body) {
+        return new Response(400, /* message */ null, /* headers */ Collections.<String, String>emptyMap(),
+                body, /* stream */ null);
     }
 }


### PR DESCRIPTION
Sometimes the request is bad and, as a user, I'd like to be able to check what is the problem.

Currently, the exception is:
```
Caused by: com.github.scribejava.core.exceptions.OAuthException: Response body is incorrect. Can't extract a '"access_token"\s*:\s*"(\S*?)"' from this: '{"error_description":"unknown, invalid, or expired refresh token","error":"invalid_grant"}
'
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extractParameter(OAuth2AccessTokenJsonExtractor.java:64)
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extract(OAuth2AccessTokenJsonExtractor.java:37)
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extract(OAuth2AccessTokenJsonExtractor.java:12)
	at com.github.scribejava.core.oauth.OAuth20Service.sendAccessTokenRequestSync(OAuth20Service.java:37)
	at com.github.scribejava.core.oauth.OAuth20Service.refreshAccessToken(OAuth20Service.java:93)
```

The pull-request replaces it by:
```
Caused by: com.github.scribejava.core.exceptions.OAuthRequestException: Get Access token error
	at com.github.scribejava.core.oauth.OAuth20Service.sendAccessTokenRequestSync(OAuth20Service.java:47)
	at com.github.scribejava.core.oauth.OAuth20Service.refreshAccessToken(OAuth20Service.java:108)
```