### PR TITLE
Update LiveApi.java

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/LiveApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/LiveApi.java
@@ -18,7 +18,7 @@ public class LiveApi extends DefaultApi20 {
 
     @Override
     public Verb getAccessTokenVerb() {
-        return Verb.GET;
+        return Verb.POST;
     }
 
     @Override
@@ -28,6 +28,6 @@ public class LiveApi extends DefaultApi20 {
 
     @Override
     protected String getAuthorizationBaseUrl() {
-        return "https://oauth.live.com/authorize";
+        return "https://login.live.com/oauth20_authorize.srf";
     }
 }


### PR DESCRIPTION
- change line 21 to Verb.POST to fix error "{"error":"invalid_request","error_description":"The provided request must be sent using the HTTP 'POST' method."}"
- update AuthorizationBaseURL