### PR TITLE
issue #722

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -88,7 +88,7 @@ public class OAuth20Service extends OAuthService {
 
     public final OAuth2AccessToken refreshAccessToken(String refreshToken) throws IOException {
         final OAuthRequest request = createRefreshTokenRequest(refreshToken,
-                new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint(), this));
+                new OAuthRequest(api.getAccessTokenVerb(), api.getRefreshTokenEndpoint(), this));
 
         return sendAccessTokenRequestSync(request);
     }


### PR DESCRIPTION
`OAuth20Service.refreshAccessToken` uses the correct URL by calling `api.getRefreshTokenEndpoint` instead of `api.getAccessTokenEndpoint`.

Very minor bugfix.