### PR TITLE
Generify OAuthService with access token type

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
@@ -178,7 +178,7 @@ public class ServiceBuilder {
      * @param api will build Service for this API
      * @return fully configured {@link S}
      */
-    public <S extends OAuthService> S build(BaseApi<S> api) {
+    public <S extends OAuthService<?>> S build(BaseApi<S> api) {
         return api.createService(createConfig());
     }
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/api/BaseApi.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/api/BaseApi.java
@@ -3,7 +3,7 @@ package com.github.scribejava.core.builder.api;
 import com.github.scribejava.core.model.OAuthConfig;
 import com.github.scribejava.core.oauth.OAuthService;
 
-public interface BaseApi<T extends OAuthService> {
+public interface BaseApi<T extends OAuthService<?>> {
 
     T createService(OAuthConfig config);
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/AbstractRequest.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/AbstractRequest.java
@@ -25,7 +25,7 @@ public abstract class AbstractRequest {
     private final ParameterList bodyParams = new ParameterList();
     private final Map<String, String> headers = new HashMap<>();
     private boolean followRedirects = true;
-    private final OAuthService service;
+    private final OAuthService<?> service;
 
     private String payload;
     private String charset;
@@ -41,7 +41,7 @@ public abstract class AbstractRequest {
      * @param url resource URL
      * @param service OAuthService
      */
-    public AbstractRequest(Verb verb, String url, OAuthService service) {
+    public AbstractRequest(Verb verb, String url, OAuthService<?> service) {
         this.verb = verb;
         this.url = url;
         this.service = service;
@@ -285,7 +285,7 @@ public abstract class AbstractRequest {
         return followRedirects;
     }
 
-    public OAuthService getService() {
+    public OAuthService<?> getService() {
         return service;
     }
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
@@ -12,7 +12,7 @@ public class OAuthRequest extends AbstractRequest {
 
     private HttpURLConnection connection;
 
-    public OAuthRequest(Verb verb, String url, OAuthService service) {
+    public OAuthRequest(Verb verb, String url, OAuthService<?> service) {
         super(verb, url, service);
     }
 

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequestAsync.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequestAsync.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Future;
 
 public class OAuthRequestAsync extends AbstractRequest {
 
-    public OAuthRequestAsync(Verb verb, String url, OAuthService service) {
+    public OAuthRequestAsync(Verb verb, String url, OAuthService<?> service) {
         super(verb, url, service);
     }
 
@@ -17,7 +17,7 @@ public class OAuthRequestAsync extends AbstractRequest {
         if (ForceTypeOfHttpRequest.FORCE_SYNC_ONLY_HTTP_REQUESTS == forceTypeOfHttpRequest) {
             throw new OAuthException("Cannot use async operations, only sync");
         }
-        final OAuthService service = getService();
+        final OAuthService<?> service = getService();
         final OAuthConfig config = service.getConfig();
         if (ForceTypeOfHttpRequest.PREFER_SYNC_ONLY_HTTP_REQUESTS == forceTypeOfHttpRequest) {
             config.log("Cannot use async operations, only sync");

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
@@ -19,7 +19,7 @@ import com.github.scribejava.core.utils.MapUtils;
 /**
  * OAuth 1.0a implementation of {@link OAuthService}
  */
-public class OAuth10aService extends OAuthService {
+public class OAuth10aService extends OAuthService<OAuth1AccessToken> {
 
     private static final String VERSION = "1.0";
     private final DefaultApi10a api;
@@ -134,6 +134,7 @@ public class OAuth10aService extends OAuthService {
         appendSignature(request);
     }
 
+    @Override
     public void signRequest(OAuth1AccessToken token, AbstractRequest request) {
         final OAuthConfig config = getConfig();
         config.log("signing request: " + request.getCompleteUrl());

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -16,7 +16,7 @@ import com.github.scribejava.core.model.OAuthRequestAsync;
 import com.github.scribejava.core.model.Response;
 import java.util.Map;
 
-public class OAuth20Service extends OAuthService {
+public class OAuth20Service extends OAuthService<OAuth2AccessToken> {
 
     private static final String VERSION = "2.0";
     private final DefaultApi20 api;
@@ -169,6 +169,7 @@ public class OAuth20Service extends OAuthService {
         return VERSION;
     }
 
+    @Override
     public void signRequest(OAuth2AccessToken accessToken, AbstractRequest request) {
         request.addQuerystringParameter(OAuthConstants.ACCESS_TOKEN, accessToken.getAccessToken());
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuthService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuthService.java
@@ -2,12 +2,14 @@ package com.github.scribejava.core.oauth;
 
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.httpclient.HttpClientProvider;
+import com.github.scribejava.core.model.AbstractRequest;
 import com.github.scribejava.core.model.ForceTypeOfHttpRequest;
 import com.github.scribejava.core.model.HttpClient;
 import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
 import com.github.scribejava.core.model.OAuthConfig;
 import com.github.scribejava.core.model.OAuthRequestAsync;
 import com.github.scribejava.core.model.ScribeJavaConfig;
+import com.github.scribejava.core.model.Token;
 import com.github.scribejava.core.model.Verb;
 
 import java.io.IOException;
@@ -20,7 +22,7 @@ import java.util.concurrent.Future;
  *
  * A facade responsible for the retrieval of request and access tokens and for the signing of HTTP requests.
  */
-public abstract class OAuthService {
+public abstract class OAuthService<T extends Token> {
 
     private final OAuthConfig config;
     private final HttpClient httpClient;
@@ -75,6 +77,8 @@ public abstract class OAuthService {
      * @return OAuth version as string
      */
     public abstract String getVersion();
+
+    public abstract void signRequest(T token, AbstractRequest request);
 
     public <T> Future<T> executeAsync(Map<String, String> headers, Verb httpVerb, String completeUrl,
             String bodyContents, OAuthAsyncRequestCallback<T> callback,

--- a/scribejava-core/src/test/java/com/github/scribejava/core/model/ForceTypeOfHttpRequestTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/model/ForceTypeOfHttpRequestTest.java
@@ -20,7 +20,7 @@ public class ForceTypeOfHttpRequestTest {
     @Before
     public void setUp() {
         ScribeJavaConfig.setForceTypeOfHttpRequests(ForceTypeOfHttpRequest.NONE);
-        final OAuthService oAuthService = new OAuth20Service(null, new OAuthConfig("test", "test"));
+        final OAuthService<?> oAuthService = new OAuth20Service(null, new OAuthConfig("test", "test"));
         request = new OAuthRequest(Verb.GET, "http://example.com?qsparam=value&other+param=value+with+spaces",
                 oAuthService);
         requestAsync = new OAuthRequestAsync(Verb.GET, "http://example.com?qsparam=value&other+param=value+with+spaces",

--- a/scribejava-core/src/test/java/com/github/scribejava/core/model/RequestTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/model/RequestTest.java
@@ -14,7 +14,7 @@ public class RequestTest {
     private OAuthRequest getRequest;
     private OAuthRequest postRequest;
     private ConnectionStub connection;
-    private OAuthService oAuthService;
+    private OAuthService<?> oAuthService;
 
     @Before
     public void setUp() throws MalformedURLException {


### PR DESCRIPTION
Generify OAuthService with access token type and pull up the abstract signRequest method. This small change helps to avoid code duplication when working with both types of social networks (OAuth 1.0 and 2.0).