### PR TITLE
Using interface instead of impl in AhcHttpClient.

### DIFF
--- a/scribejava-httpclient-ahc/src/main/java/com/github/scribejava/httpclient/ahc/AhcHttpClient.java
+++ b/scribejava-httpclient-ahc/src/main/java/com/github/scribejava/httpclient/ahc/AhcHttpClient.java
@@ -24,7 +24,7 @@ public class AhcHttpClient implements HttpClient {
         client = new DefaultAsyncHttpClient(ahcConfig.getClientConfig());
     }
 
-    public AhcHttpClient(DefaultAsyncHttpClient ahcClient) {
+    public AhcHttpClient(AsyncHttpClient ahcClient) {
         client = ahcClient;
     }
 


### PR DESCRIPTION
I'd like to use com.github.scribejava.httpclient.ahc.AhcHttpClient with my own implementation of AsyncHttpClient and not DefaultAsyncHttpClient.