### PR TITLE
Add support for specifying the desired lifetime of the access token.

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
@@ -24,6 +24,7 @@ public class ServiceBuilder {
     private OutputStream debugStream;
     private String responseType = "code";
     private String userAgent;
+    private Integer expiresIn;
 
     //sync version only
     private Integer connectTimeout;
@@ -155,6 +156,11 @@ public class ServiceBuilder {
         this.userAgent = userAgent;
         return this;
     }
+    
+    public ServiceBuilder expiresIn(Integer expiresIn) {
+        this.expiresIn = expiresIn;
+        return this;
+    }
 
     public ServiceBuilder debug() {
         debugStream(System.out);
@@ -168,7 +174,7 @@ public class ServiceBuilder {
     private OAuthConfig createConfig() {
         checkPreconditions();
         return new OAuthConfig(apiKey, apiSecret, callback, signatureType, scope, debugStream, state, responseType,
-                userAgent, connectTimeout, readTimeout, httpClientConfig, httpClient);
+                userAgent, expiresIn, connectTimeout, readTimeout, httpClientConfig, httpClient);
     }
 
     /**

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
@@ -17,6 +17,8 @@ public class OAuthConfig {
     private final String state;
     private final String responseType;
     private final String userAgent;
+    private final String expiresIn;
+
 
     //sync only version
     private final Integer connectTimeout;
@@ -27,11 +29,11 @@ public class OAuthConfig {
     private HttpClient httpClient;
 
     public OAuthConfig(String key, String secret) {
-        this(key, secret, null, null, null, null, null, null, null, null, null, null, null);
+        this(key, secret, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public OAuthConfig(String apiKey, String apiSecret, String callback, SignatureType signatureType, String scope,
-            OutputStream debugStream, String state, String responseType, String userAgent, Integer connectTimeout,
+            OutputStream debugStream, String state, String responseType, String userAgent, String expiresIn, Integer connectTimeout,
             Integer readTimeout, HttpClient.Config httpClientConfig, HttpClient httpClient) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret;
@@ -42,6 +44,7 @@ public class OAuthConfig {
         this.state = state;
         this.responseType = responseType;
         this.userAgent = userAgent;
+        this.expiresIn = expiresIn;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.httpClientConfig = httpClientConfig;
@@ -78,6 +81,10 @@ public class OAuthConfig {
 
     public String getUserAgent() {
         return userAgent;
+    }
+    
+    public String getExpiresIn() {
+        return expiresIn;
     }
 
     public void log(String message) {

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConfig.java
@@ -17,7 +17,7 @@ public class OAuthConfig {
     private final String state;
     private final String responseType;
     private final String userAgent;
-    private final String expiresIn;
+    private final Integer expiresIn;
 
 
     //sync only version
@@ -33,7 +33,7 @@ public class OAuthConfig {
     }
 
     public OAuthConfig(String apiKey, String apiSecret, String callback, SignatureType signatureType, String scope,
-            OutputStream debugStream, String state, String responseType, String userAgent, String expiresIn, Integer connectTimeout,
+            OutputStream debugStream, String state, String responseType, String userAgent, Integer expiresIn, Integer connectTimeout,
             Integer readTimeout, HttpClient.Config httpClientConfig, HttpClient httpClient) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret;
@@ -83,7 +83,7 @@ public class OAuthConfig {
         return userAgent;
     }
     
-    public String getExpiresIn() {
+    public Integer getExpiresIn() {
         return expiresIn;
     }
 

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConstants.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConstants.java
@@ -37,6 +37,7 @@ public interface OAuthConstants {
     String PASSWORD = "password";
     String RESPONSE_TYPE = "response_type";
     String RESPONSE_TYPE_CODE = "code";
+    String EXPIRES_IN = "expires_in";
 
     //not OAuth specific
     String USER_AGENT_HEADER_NAME = "User-Agent";

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -82,6 +82,10 @@ public class OAuth20Service extends OAuthService<OAuth2AccessToken> {
         if (scope != null) {
             request.addParameter(OAuthConstants.SCOPE, scope);
         }
+        final String expires_In = config.getExpiresIn();
+        if (expires_In != null) {
+            request.addParameter(OAuthConstants.EXPIRES_IN, expires_In);
+        }
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.AUTHORIZATION_CODE);
         return request;
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -82,7 +82,7 @@ public class OAuth20Service extends OAuthService<OAuth2AccessToken> {
         if (scope != null) {
             request.addParameter(OAuthConstants.SCOPE, scope);
         }
-        final String expires_In = config.getExpiresIn();
+        final Integer expires_In = config.getExpiresIn();
         if (expires_In != null) {
             request.addParameter(OAuthConstants.EXPIRES_IN, expires_In);
         }


### PR DESCRIPTION
When using the _Implicit Grant Flow_, example is shown in https://dev.fitbit.com/docs/oauth2/ it would be beneficial to be able to set the desired lifetime of the access token.

I modified the code to support this.

![expires_in](https://cloud.githubusercontent.com/assets/14874913/21004844/21b02a82-bd3b-11e6-9a65-7353dc3c8332.JPG)
