### PR TITLE
issue #753

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
@@ -75,7 +75,7 @@ public class OAuth10aService extends OAuthService<OAuth1AccessToken> {
         return request;
     }
 
-    private void addOAuthParams(OAuthRequest request, String tokenSecret) {
+    protected void addOAuthParams(OAuthRequest request, String tokenSecret) {
         final OAuthConfig config = getConfig();
         request.addOAuthParameter(OAuthConstants.TIMESTAMP, api.getTimestampService().getTimestampInSeconds());
         request.addOAuthParameter(OAuthConstants.NONCE, api.getTimestampService().getNonce());
@@ -177,7 +177,7 @@ public class OAuth10aService extends OAuthService<OAuth1AccessToken> {
         return signature;
     }
 
-    private void appendSignature(OAuthRequest request) {
+    protected void appendSignature(OAuthRequest request) {
         final OAuthConfig config = getConfig();
         switch (config.getSignatureType()) {
             case Header:


### PR DESCRIPTION
Makes `addOAuthParams` and `appendSignature` `protected final`, so that they can be used from overridden `prepareRequestTokenRequest` methods in subclasses. Since it does not make sense to override these methods, they have been marked as `final` as well.