### PR TITLE
Only add secret key if set

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -123,7 +123,9 @@ public class OAuth20Service extends OAuthService<OAuth2AccessToken> {
         final OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getRefreshTokenEndpoint());
         final OAuthConfig config = getConfig();
         request.addParameter(OAuthConstants.CLIENT_ID, config.getApiKey());
-        request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+        if (config.getApiSecret() != null) {
+            request.addParameter(OAuthConstants.CLIENT_SECRET, config.getApiSecret());
+        }
         request.addParameter(OAuthConstants.REFRESH_TOKEN, refreshToken);
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.REFRESH_TOKEN);
         return request;


### PR DESCRIPTION
Some providers (e.g. Google) don't use the secret key anymore. We need to allow refreshing the token without setting said key.