### PR TITLE
Apache http client integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>scribejava-httpclient-ahc</module>
         <module>scribejava-httpclient-ning</module>
         <module>scribejava-httpclient-okhttp</module>
+        <module>scribejava-httpclient-apache</module>
     </modules>
 
     <licenses>

--- a/scribejava-core/pom.xml
+++ b/scribejava-core/pom.xml
@@ -14,6 +14,15 @@
     <name>ScribeJava Core</name>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -23,6 +32,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
@@ -33,9 +33,13 @@ public class JDKHttpClient implements HttpClient {
     public <T> Future<T> executeAsync(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
             byte[] bodyContents, OAuthAsyncRequestCallback<T> callback, OAuthRequest.ResponseConverter<T> converter) {
         try {
-            final T response = converter.convert(execute(userAgent, headers, httpVerb, completeUrl, bodyContents));
-            callback.onCompleted(response);
-            return new JDKHttpFuture<>(response);
+            final Response response = execute(userAgent, headers, httpVerb, completeUrl, bodyContents);
+            @SuppressWarnings("unchecked")
+            final T t = converter == null ? (T) response : converter.convert(response);
+            if (callback != null) {
+                callback.onCompleted(t);
+            }
+            return new JDKHttpFuture<>(t);
         } catch (InterruptedException | ExecutionException | IOException e) {
             callback.onThrowable(e);
             return new JDKHttpFuture<>(e);
@@ -46,11 +50,13 @@ public class JDKHttpClient implements HttpClient {
     public <T> Future<T> executeAsync(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
             String bodyContents, OAuthAsyncRequestCallback<T> callback, OAuthRequest.ResponseConverter<T> converter) {
         try {
-            final T response = converter.convert(execute(userAgent, headers, httpVerb, completeUrl, bodyContents));
+            final Response response = execute(userAgent, headers, httpVerb, completeUrl, bodyContents);
+            @SuppressWarnings("unchecked")
+            final T t = converter == null ? (T) response : converter.convert(response);
             if (callback != null) {
-                callback.onCompleted(response);
+                callback.onCompleted(t);
             }
-            return new JDKHttpFuture<>(response);
+            return new JDKHttpFuture<>(t);
         } catch (InterruptedException | ExecutionException | IOException e) {
             if (callback != null) {
                 callback.onThrowable(e);

--- a/scribejava-core/src/test/java/com/github/scribejava/core/AbstractClientTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/AbstractClientTest.java
@@ -1,0 +1,178 @@
+package com.github.scribejava.core;
+
+import com.github.scribejava.core.httpclient.HttpClient;
+import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
+import com.github.scribejava.core.model.OAuthConfig;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import com.github.scribejava.core.oauth.OAuthService;
+import com.github.scribejava.core.utils.StreamUtils;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractClientTest {
+
+    class TestCallback<T> implements OAuthAsyncRequestCallback<T> {
+
+        private Throwable throwable;
+        private T response;
+
+        @Override
+        public void onCompleted(T response) {
+            this.response = response;
+        }
+
+        @Override
+        public void onThrowable(Throwable throwable) {
+            this.throwable = throwable;
+        }
+    }
+
+    private OAuthService<?> oAuthService;
+    private HttpClient client;
+
+    @Before
+    public void setUp() {
+        client = createNewClient();
+        oAuthService = new OAuth20Service(null,
+                new OAuthConfig("test", "test", null, null, null, null, null, null, null, client));
+    }
+
+    @After
+    public void shutDown() throws IOException {
+        client.close();
+    }
+
+    protected abstract HttpClient createNewClient();
+
+    @Test
+    public void shouldSendGetRequest() throws Exception {
+        final String expectedResponseBody = "response body";
+
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(expectedResponseBody));
+        server.start();
+
+        final HttpUrl baseUrl = server.url("/testUrl");
+
+        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
+        final Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
+
+        assertEquals(expectedResponseBody, response.getBody());
+
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertEquals("GET", recordedRequest.getMethod());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldSendPostRequest() throws Exception {
+        final String expectedResponseBody = "response body";
+        final String expectedRequestBody = "request body";
+
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(expectedResponseBody));
+        server.enqueue(new MockResponse().setBody(expectedResponseBody));
+        server.start();
+
+        final HttpUrl baseUrl = server.url("/testUrl");
+
+        // request with body
+        OAuthRequest request = new OAuthRequest(Verb.POST, baseUrl.toString());
+        request.setPayload(expectedRequestBody);
+        Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
+
+        assertEquals(expectedResponseBody, response.getBody());
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals(expectedRequestBody, recordedRequest.getBody().readUtf8());
+
+
+        // request with empty body
+        request = new OAuthRequest(Verb.POST, baseUrl.toString());
+        response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
+
+        assertEquals(expectedResponseBody, response.getBody());
+
+        recordedRequest = server.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals("", recordedRequest.getBody().readUtf8());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldReadResponseStream() throws Exception {
+        final String expectedResponseBody = "response body";
+
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(expectedResponseBody));
+        server.start();
+
+        final HttpUrl baseUrl = server.url("/testUrl");
+
+        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
+        final Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
+
+        assertEquals(expectedResponseBody, StreamUtils.getStreamContents(response.getStream()));
+
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertEquals("GET", recordedRequest.getMethod());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldCallCallback() throws Exception {
+        final String expectedResponseBody = "response body";
+
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(expectedResponseBody));
+        server.start();
+
+        final HttpUrl baseUrl = server.url("/testUrl");
+
+        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
+
+        final TestCallback<Response> callback = new TestCallback<>();
+        oAuthService.execute(request, callback).get();
+
+        assertEquals(expectedResponseBody, callback.response.getBody());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void shouldPassErrors() throws Exception {
+
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.start();
+
+        final HttpUrl baseUrl = server.url("/testUrl");
+
+        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
+
+        final TestCallback<Response> callback = new TestCallback<>();
+        final Response response = oAuthService.execute(request, callback).get();
+
+        assertEquals(500, response.getCode());
+        assertEquals(500, callback.response.getCode());
+
+        server.shutdown();
+    }
+}

--- a/scribejava-core/src/test/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClientTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClientTest.java
@@ -1,0 +1,12 @@
+package com.github.scribejava.core.httpclient.jdk;
+
+import com.github.scribejava.core.AbstractClientTest;
+import com.github.scribejava.core.httpclient.HttpClient;
+
+public class JDKHttpClientTest extends AbstractClientTest {
+
+    @Override
+    protected HttpClient createNewClient() {
+        return new JDKHttpClient(JDKHttpClientConfig.defaultConfig());
+    }
+}

--- a/scribejava-httpclient-ahc/pom.xml
+++ b/scribejava-httpclient-ahc/pom.xml
@@ -25,6 +25,19 @@
             <artifactId>async-http-client</artifactId>
             <version>2.0.33</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scribejava-httpclient-ahc/src/test/java/com/github/scribejava/httpclient/ahc/AhcHttpClientTest.java
+++ b/scribejava-httpclient-ahc/src/test/java/com/github/scribejava/httpclient/ahc/AhcHttpClientTest.java
@@ -1,0 +1,12 @@
+package com.github.scribejava.httpclient.ahc;
+
+import com.github.scribejava.core.AbstractClientTest;
+import com.github.scribejava.core.httpclient.HttpClient;
+
+public class AhcHttpClientTest extends AbstractClientTest {
+
+    @Override
+    protected HttpClient createNewClient() {
+        return new AhcHttpClient(AhcHttpClientConfig.defaultConfig());
+    }
+}

--- a/scribejava-httpclient-apache/pom.xml
+++ b/scribejava-httpclient-apache/pom.xml
@@ -10,8 +10,8 @@
     </parent>
     
     <groupId>com.github.scribejava</groupId>
-    <artifactId>scribejava-httpclient-ning</artifactId>
-    <name>ScribeJava Ning Async Http Client support</name>
+    <artifactId>scribejava-httpclient-apache</artifactId>
+    <name>ScribeJava Apache Http Client support</name>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -21,9 +21,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.ning</groupId>
-            <artifactId>async-http-client</artifactId>
-            <version>1.9.40</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.1.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>

--- a/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpClient.java
+++ b/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpClient.java
@@ -1,0 +1,109 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.httpclient.AbstractAsyncOnlyHttpClient;
+import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Verb;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class ApacheHttpClient extends AbstractAsyncOnlyHttpClient {
+
+    private final CloseableHttpAsyncClient client;
+
+    public ApacheHttpClient() {
+        this(HttpAsyncClients.createDefault());
+    }
+
+    public ApacheHttpClient(CloseableHttpAsyncClient client) {
+        this.client = client;
+        this.client.start();
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+
+    @Override
+    public <T> Future<T> executeAsync(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+            byte[] bodyContents, OAuthAsyncRequestCallback<T> callback, OAuthRequest.ResponseConverter<T> converter) {
+        final HttpEntity entity = bodyContents == null ? null : new ByteArrayEntity(bodyContents);
+        return doExecuteAsync(userAgent, headers, httpVerb, completeUrl, entity, callback, converter);
+    }
+
+    @Override
+    public <T> Future<T> executeAsync(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+            String bodyContents, OAuthAsyncRequestCallback<T> callback, OAuthRequest.ResponseConverter<T> converter) {
+        final HttpEntity entity = bodyContents == null ? null : new StringEntity(bodyContents, StandardCharsets.UTF_8);
+        return doExecuteAsync(userAgent, headers, httpVerb, completeUrl, entity, callback, converter);
+    }
+
+    @Override
+    public <T> Future<T> executeAsync(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+            File bodyContents, OAuthAsyncRequestCallback<T> callback, OAuthRequest.ResponseConverter<T> converter) {
+        final HttpEntity entity = bodyContents == null ? null : new FileEntity(bodyContents);
+        return doExecuteAsync(userAgent, headers, httpVerb, completeUrl, entity, callback, converter);
+    }
+
+    private <T> Future<T> doExecuteAsync(String userAgent, Map<String, String> headers, Verb httpVerb,
+            String completeUrl, HttpEntity entity, OAuthAsyncRequestCallback<T> callback,
+            OAuthRequest.ResponseConverter<T> converter) {
+        final RequestBuilder builder = getRequestBuilder(httpVerb);
+        builder.setUri(completeUrl);
+
+        if (httpVerb.isPermitBody()) {
+            if (!headers.containsKey(CONTENT_TYPE)) {
+                builder.addHeader(CONTENT_TYPE, DEFAULT_CONTENT_TYPE);
+            }
+            builder.setEntity(entity);
+        }
+
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            builder.addHeader(header.getKey(), header.getValue());
+        }
+
+        if (userAgent != null) {
+            builder.setHeader(OAuthConstants.USER_AGENT_HEADER_NAME, userAgent);
+        }
+        final OAuthAsyncCompletionHandler<T> handler = new OAuthAsyncCompletionHandler<>(callback, converter);
+        final Future<HttpResponse> future = client.execute(builder.build(), handler);
+        return new ApacheHttpFuture<>(future, handler);
+    }
+
+    private RequestBuilder getRequestBuilder(Verb httpVerb) {
+        switch (httpVerb) {
+            case GET:
+                return RequestBuilder.get();
+            case PUT:
+                return RequestBuilder.put();
+            case DELETE:
+                return RequestBuilder.delete();
+            case HEAD:
+                return RequestBuilder.head();
+            case POST:
+                return RequestBuilder.post();
+            case PATCH:
+                return RequestBuilder.patch();
+            case TRACE:
+                return RequestBuilder.trace();
+            case OPTIONS:
+                return RequestBuilder.options();
+            default:
+                throw new IllegalArgumentException("message build error: unknown verb type");
+        }
+    }
+}

--- a/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpClientConfig.java
+++ b/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpClientConfig.java
@@ -1,0 +1,15 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.httpclient.HttpClientConfig;
+
+public class ApacheHttpClientConfig implements HttpClientConfig {
+
+    @Override
+    public HttpClientConfig createDefaultConfig() {
+        return defaultConfig();
+    }
+
+    public static ApacheHttpClientConfig defaultConfig() {
+        return new ApacheHttpClientConfig();
+    }
+}

--- a/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpFuture.java
+++ b/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheHttpFuture.java
@@ -1,0 +1,44 @@
+package com.github.scribejava.httpclient.apache;
+
+import org.apache.http.HttpResponse;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ApacheHttpFuture<T> implements Future<T> {
+
+    private final Future<HttpResponse> future;
+    private final OAuthAsyncCompletionHandler<T> handler;
+
+    public ApacheHttpFuture(Future<HttpResponse> future, OAuthAsyncCompletionHandler<T> handler) {
+        this.future = future;
+        this.handler = handler;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return future.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return future.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return future.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return handler.getResult();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return handler.getResult(timeout, unit);
+    }
+}

--- a/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheProvider.java
+++ b/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/ApacheProvider.java
@@ -1,0 +1,16 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.httpclient.HttpClient;
+import com.github.scribejava.core.httpclient.HttpClientConfig;
+import com.github.scribejava.core.httpclient.HttpClientProvider;
+
+public class ApacheProvider implements HttpClientProvider {
+
+    @Override
+    public HttpClient createClient(HttpClientConfig httpClientConfig) {
+        if (httpClientConfig instanceof ApacheHttpClientConfig) {
+            return new ApacheHttpClient();
+        }
+        return null;
+    }
+}

--- a/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/OAuthAsyncCompletionHandler.java
+++ b/scribejava-httpclient-apache/src/main/java/com/github/scribejava/httpclient/apache/OAuthAsyncCompletionHandler.java
@@ -1,0 +1,95 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
+import com.github.scribejava.core.model.OAuthRequest.ResponseConverter;
+import com.github.scribejava.core.model.Response;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class OAuthAsyncCompletionHandler<T> implements FutureCallback<HttpResponse> {
+
+    private final ResponseConverter<T> converter;
+    private final OAuthAsyncRequestCallback<T> callback;
+    private final CountDownLatch latch;
+    private T result;
+    private Exception exception;
+
+    public OAuthAsyncCompletionHandler(OAuthAsyncRequestCallback<T> callback, ResponseConverter<T> converter) {
+        this.converter = converter;
+        this.callback = callback;
+        this.latch = new CountDownLatch(1);
+    }
+
+    @Override
+    public void completed(HttpResponse httpResponse) {
+        try {
+            final Map<String, String> headersMap = Stream.of(httpResponse.getAllHeaders())
+                    .collect(Collectors.toMap(Header::getName, Header::getValue));
+            final Response response = new Response(httpResponse.getStatusLine().getStatusCode(),
+                    httpResponse.getStatusLine().getReasonPhrase(), headersMap, httpResponse.getEntity().getContent());
+            @SuppressWarnings("unchecked")
+            final T t = converter == null ? (T) response : converter.convert(response);
+            result = t;
+            if (callback != null) {
+                callback.onCompleted(result);
+            }
+        } catch (IOException e) {
+            exception = e;
+            if (callback != null) {
+                callback.onThrowable(e);
+            }
+        } finally {
+            latch.countDown();
+        }
+    }
+
+    @Override
+    public void failed(Exception e) {
+        exception = e;
+        try {
+            if (callback != null) {
+                callback.onThrowable(e);
+            }
+        } finally {
+            latch.countDown();
+        }
+    }
+
+    @Override
+    public void cancelled() {
+        exception = new CancellationException();
+        try {
+            if (callback != null) {
+                callback.onThrowable(exception);
+            }
+        } finally {
+            latch.countDown();
+        }
+    }
+
+    public T getResult() throws InterruptedException, ExecutionException {
+        latch.await();
+        if (exception != null) {
+            throw new ExecutionException(exception);
+        }
+        return result;
+    }
+
+    public T getResult(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+        latch.await(timeout, unit);
+        if (exception != null) {
+            throw new ExecutionException(exception);
+        }
+        return result;
+    }
+}

--- a/scribejava-httpclient-apache/src/test/java/com/github/scribejava/httpclient/apache/ApacheHttpClientTest.java
+++ b/scribejava-httpclient-apache/src/test/java/com/github/scribejava/httpclient/apache/ApacheHttpClientTest.java
@@ -1,0 +1,13 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.AbstractClientTest;
+import com.github.scribejava.core.httpclient.HttpClient;
+
+public class ApacheHttpClientTest extends AbstractClientTest {
+
+    @Override
+    protected HttpClient createNewClient() {
+        return new ApacheHttpClient();
+    }
+
+}

--- a/scribejava-httpclient-apache/src/test/java/com/github/scribejava/httpclient/apache/OauthAsyncCompletionHandlerTest.java
+++ b/scribejava-httpclient-apache/src/test/java/com/github/scribejava/httpclient/apache/OauthAsyncCompletionHandlerTest.java
@@ -1,0 +1,128 @@
+package com.github.scribejava.httpclient.apache;
+
+import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class OauthAsyncCompletionHandlerTest {
+
+    private OAuthAsyncCompletionHandler<String> handler;
+    private TestCallback callback;
+
+    class TestCallback implements OAuthAsyncRequestCallback<String> {
+
+        private Throwable throwable;
+        private String response;
+
+        @Override
+        public void onCompleted(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public void onThrowable(Throwable throwable) {
+            this.throwable = throwable;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        callback = new TestCallback();
+    }
+
+    @Test
+    public void shouldReleaseLatchOnSuccess() throws Exception {
+        handler = new OAuthAsyncCompletionHandler<>(callback, response -> "All good");
+        final HttpResponse response = new BasicHttpResponse(new BasicStatusLine(
+                new ProtocolVersion("4", 1, 1), 200, "ok"));
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream(new byte[0]));
+        response.setEntity(entity);
+        handler.completed(response);
+        assertNotNull(callback.response);
+        assertNull(callback.throwable);
+        // verify latch is released
+        assertEquals("All good", handler.getResult());
+    }
+
+    @Test
+    public void shouldReleaseLatchOnIOException() throws Exception {
+        handler = new OAuthAsyncCompletionHandler<>(callback, response -> {
+            throw new IOException("Failed to convert");
+        });
+        final HttpResponse response = new BasicHttpResponse(new BasicStatusLine(
+                new ProtocolVersion("4", 1, 1), 200, "ok"));
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream(new byte[0]));
+        response.setEntity(entity);
+        handler.completed(response);
+        assertNull(callback.response);
+        assertNotNull(callback.throwable);
+        assertTrue(callback.throwable instanceof IOException);
+        // verify latch is released
+        try {
+            handler.getResult();
+            fail();
+        } catch (ExecutionException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldReleaseLatchOnCancel() throws Exception {
+        handler = new OAuthAsyncCompletionHandler<>(callback, response -> "All good");
+        final HttpResponse response = new BasicHttpResponse(new BasicStatusLine(
+                new ProtocolVersion("4", 1, 1), 200, "ok"));
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream(new byte[0]));
+        response.setEntity(entity);
+        handler.cancelled();
+        assertNull(callback.response);
+        assertNotNull(callback.throwable);
+        assertTrue(callback.throwable instanceof CancellationException);
+        // verify latch is released
+        try {
+            handler.getResult();
+            fail();
+        } catch (ExecutionException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldReleaseLatchOnFailure() throws Exception {
+        handler = new OAuthAsyncCompletionHandler<>(callback, response -> "All good");
+        final HttpResponse response = new BasicHttpResponse(new BasicStatusLine(
+                new ProtocolVersion("4", 1, 1), 200, "ok"));
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream(new byte[0]));
+        response.setEntity(entity);
+        handler.failed(new RuntimeException());
+        assertNull(callback.response);
+        assertNotNull(callback.throwable);
+        assertTrue(callback.throwable instanceof RuntimeException);
+        // verify latch is released
+        try {
+            handler.getResult();
+            fail();
+        } catch (ExecutionException expected) {
+            // expected
+        }
+    }
+}

--- a/scribejava-httpclient-ning/src/test/java/com/github/scribejava/httpclient/ning/NingHttpClientTest.java
+++ b/scribejava-httpclient-ning/src/test/java/com/github/scribejava/httpclient/ning/NingHttpClientTest.java
@@ -1,0 +1,13 @@
+package com.github.scribejava.httpclient.ning;
+
+import com.github.scribejava.core.AbstractClientTest;
+import com.github.scribejava.core.httpclient.HttpClient;
+import com.ning.http.client.AsyncHttpClient;
+
+public class NingHttpClientTest extends AbstractClientTest {
+
+    @Override
+    protected HttpClient createNewClient() {
+        return new NingHttpClient(new AsyncHttpClient());
+    }
+}

--- a/scribejava-httpclient-okhttp/pom.xml
+++ b/scribejava-httpclient-okhttp/pom.xml
@@ -31,6 +31,13 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scribejava-httpclient-okhttp/src/test/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClientTest.java
+++ b/scribejava-httpclient-okhttp/src/test/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClientTest.java
@@ -1,112 +1,13 @@
 package com.github.scribejava.httpclient.okhttp;
 
+import com.github.scribejava.core.AbstractClientTest;
 import com.github.scribejava.core.httpclient.HttpClient;
-import com.github.scribejava.core.model.OAuthConfig;
-import com.github.scribejava.core.model.OAuthRequest;
-import com.github.scribejava.core.model.Response;
-import com.github.scribejava.core.model.Verb;
-import com.github.scribejava.core.oauth.OAuth20Service;
-import com.github.scribejava.core.oauth.OAuthService;
-import com.github.scribejava.core.utils.StreamUtils;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Before;
-import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
+public class OkHttpHttpClientTest extends AbstractClientTest {
 
-import static org.junit.Assert.assertEquals;
-
-public class OkHttpHttpClientTest {
-    private OAuthService<?> oAuthService;
-
-    @Before
-    public void setUp() {
-        final HttpClient client = new OkHttpHttpClient(new OkHttpClient());
-        oAuthService = new OAuth20Service(null,
-                new OAuthConfig("test", "test", null, null, null, null, null, null, null, client));
-    }
-
-
-    @Test
-    public void shouldSendGetRequest() throws Exception {
-        final String expectedResponseBody = "response body";
-
-        final MockWebServer server = new MockWebServer();
-        server.enqueue(new MockResponse().setBody(expectedResponseBody));
-        server.start();
-
-        final HttpUrl baseUrl = server.url("/testUrl");
-
-        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
-        final Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
-
-        assertEquals(expectedResponseBody, response.getBody());
-
-        final RecordedRequest recordedRequest = server.takeRequest();
-        assertEquals("GET", recordedRequest.getMethod());
-
-        server.shutdown();
-    }
-
-    @Test
-    public void shouldSendPostRequest() throws Exception {
-        final String expectedResponseBody = "response body";
-        final String expectedRequestBody = "request body";
-
-        final MockWebServer server = new MockWebServer();
-        server.enqueue(new MockResponse().setBody(expectedResponseBody));
-        server.enqueue(new MockResponse().setBody(expectedResponseBody));
-        server.start();
-
-        final HttpUrl baseUrl = server.url("/testUrl");
-
-        // request with body
-        OAuthRequest request = new OAuthRequest(Verb.POST, baseUrl.toString());
-        request.setPayload(expectedRequestBody);
-        Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
-
-        assertEquals(expectedResponseBody, response.getBody());
-
-        RecordedRequest recordedRequest = server.takeRequest();
-        assertEquals("POST", recordedRequest.getMethod());
-        assertEquals(expectedRequestBody, recordedRequest.getBody().readUtf8());
-
-
-        // request with empty body
-        request = new OAuthRequest(Verb.POST, baseUrl.toString());
-        response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
-
-        assertEquals(expectedResponseBody, response.getBody());
-
-        recordedRequest = server.takeRequest();
-        assertEquals("POST", recordedRequest.getMethod());
-        assertEquals("", recordedRequest.getBody().readUtf8());
-
-        server.shutdown();
-    }
-
-    @Test
-    public void shouldReadResponseStream() throws Exception {
-        final String expectedResponseBody = "response body";
-
-        final MockWebServer server = new MockWebServer();
-        server.enqueue(new MockResponse().setBody(expectedResponseBody));
-        server.start();
-
-        final HttpUrl baseUrl = server.url("/testUrl");
-
-        final OAuthRequest request = new OAuthRequest(Verb.GET, baseUrl.toString());
-        final Response response = oAuthService.execute(request, null).get(30, TimeUnit.SECONDS);
-
-        assertEquals(expectedResponseBody, StreamUtils.getStreamContents(response.getStream()));
-
-        final RecordedRequest recordedRequest = server.takeRequest();
-        assertEquals("GET", recordedRequest.getMethod());
-
-        server.shutdown();
+    @Override
+    protected HttpClient createNewClient() {
+        return new OkHttpHttpClient(new OkHttpClient());
     }
 }


### PR DESCRIPTION
This adds Apache's HttpClient as a new http client.

Additionally, the `OkHttpHttpClientTest` has been refactored, and is now used for all clients.