### PR TITLE
Convert Tumblr api request urls to https

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/TumblrApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/TumblrApi.java
@@ -6,8 +6,8 @@ import com.github.scribejava.core.model.OAuth1RequestToken;
 public class TumblrApi extends DefaultApi10a {
 
     private static final String AUTHORIZE_URL = "https://www.tumblr.com/oauth/authorize?oauth_token=%s";
-    private static final String REQUEST_TOKEN_RESOURCE = "http://www.tumblr.com/oauth/request_token";
-    private static final String ACCESS_TOKEN_RESOURCE = "http://www.tumblr.com/oauth/access_token";
+    private static final String REQUEST_TOKEN_RESOURCE = "https://www.tumblr.com/oauth/request_token";
+    private static final String ACCESS_TOKEN_RESOURCE = "https://www.tumblr.com/oauth/access_token";
 
     protected TumblrApi() {
     }


### PR DESCRIPTION
Tumblr seems to have changed their API to refuse requests that are not using HTTPS. 
These urls are listed [here](https://www.tumblr.com/docs/en/api/v2#auth).