### PR TITLE
Added SSL URLs for Tumblr API

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/TumblrApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/TumblrApi.java
@@ -6,8 +6,8 @@ import com.github.scribejava.core.model.OAuth1RequestToken;
 public class TumblrApi extends DefaultApi10a {
 
     private static final String AUTHORIZE_URL = "https://www.tumblr.com/oauth/authorize?oauth_token=%s";
-    private static final String REQUEST_TOKEN_RESOURCE = "http://www.tumblr.com/oauth/request_token";
-    private static final String ACCESS_TOKEN_RESOURCE = "http://www.tumblr.com/oauth/access_token";
+    private static final String REQUEST_TOKEN_RESOURCE = "https://www.tumblr.com/oauth/request_token";
+    private static final String ACCESS_TOKEN_RESOURCE = "https://www.tumblr.com/oauth/access_token";
 
     protected TumblrApi() {
     }


### PR DESCRIPTION
Tumblr was giving error while requesting token, the error code was 307 which was a redirect from `http` to `https`. This PR is just a small change for making `http` to `https`.