### PR TITLE
Sets client authentication type to 'request body' for Pinterest

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/PinterestApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/PinterestApi.java
@@ -1,5 +1,6 @@
 package com.github.scribejava.apis;
 
+import com.github.scribejava.core.builder.api.ClientAuthenticationType;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.builder.api.OAuth2SignatureType;
 
@@ -29,5 +30,10 @@ public class PinterestApi extends DefaultApi20 {
     @Override
     public OAuth2SignatureType getSignatureType() {
         return OAuth2SignatureType.BEARER_URI_QUERY_PARAMETER;
+    }
+
+    @Override
+    public ClientAuthenticationType getClientAuthenticationType() {
+        return ClientAuthenticationType.REQUEST_BODY;
     }
 }


### PR DESCRIPTION
It looks like Pinterest has the same bug as LinkedIn: https://github.com/scribejava/scribejava/issues/811