### PR TITLE
Add multipart form-data request to JDK Http Client

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/AbstractAsyncOnlyHttpClient.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/AbstractAsyncOnlyHttpClient.java
@@ -30,4 +30,10 @@ public abstract class AbstractAsyncOnlyHttpClient implements HttpClient {
         return executeAsync(userAgent, headers, httpVerb, completeUrl, bodyContents, null,
                 (OAuthRequest.ResponseConverter<Response>) null).get();
     }
+    
+    @Override
+	public Response execute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+			OAuthRequest.MultipartPayloads multipartPayloads) throws InterruptedException, ExecutionException, IOException {
+		throw new UnsupportedOperationException("This HttpClient does not support Multipart payload for the moment");
+	}
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/HttpClient.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/HttpClient.java
@@ -27,6 +27,9 @@ public interface HttpClient extends Closeable {
 
     Response execute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
             byte[] bodyContents) throws InterruptedException, ExecutionException, IOException;
+    
+    Response execute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+            OAuthRequest.MultipartPayloads multipartPayloads) throws InterruptedException, ExecutionException, IOException;
 
     Response execute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
             String bodyContents) throws InterruptedException, ExecutionException, IOException;

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuthService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuthService.java
@@ -123,7 +123,11 @@ public abstract class OAuthService implements Closeable {
         } else if (request.getStringPayload() != null) {
             return httpClient.execute(userAgent, request.getHeaders(), request.getVerb(), request.getCompleteUrl(),
                     request.getStringPayload());
-        } else {
+        } else if (request.getMultipartPayloads() != null) {
+        	return httpClient.execute(userAgent, request.getHeaders(), request.getVerb(), request.getCompleteUrl(),
+        			request.getMultipartPayloads());
+        }
+        else {
             return httpClient.execute(userAgent, request.getHeaders(), request.getVerb(), request.getCompleteUrl(),
                     request.getByteArrayPayload());
         }

--- a/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClient.java
+++ b/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClient.java
@@ -4,6 +4,7 @@ import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
 import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.OAuthRequest.MultipartPayloads;
 import com.github.scribejava.core.model.Verb;
 import okhttp3.Call;
 import okhttp3.MediaType;
@@ -11,11 +12,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.internal.http.HttpMethod;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Future;
-
 import com.github.scribejava.core.model.Response;
 import java.io.File;
 import java.util.HashMap;
@@ -101,6 +100,12 @@ public class OkHttpHttpClient implements HttpClient {
         return doExecute(userAgent, headers, httpVerb, completeUrl, BodyType.FILE, bodyContents);
     }
 
+	@Override
+	public Response execute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
+			MultipartPayloads multipartPayloads) throws InterruptedException, ExecutionException, IOException {
+		throw new UnsupportedOperationException("OKHttpClient does not support Multipart payload for the moment");
+	}
+    
     private Response doExecute(String userAgent, Map<String, String> headers, Verb httpVerb, String completeUrl,
             BodyType bodyType, Object bodyContents) throws IOException {
         final Call call = createCall(userAgent, headers, httpVerb, completeUrl, bodyType, bodyContents);
@@ -174,6 +179,6 @@ public class OkHttpHttpClient implements HttpClient {
         final ResponseBody body = okHttpResponse.body();
         return new Response(okHttpResponse.code(), okHttpResponse.message(), headersMap,
                 body == null ? null : body.byteStream());
-
     }
+
 }


### PR DESCRIPTION
Changes to be committed:

1. 	scribejava-core/src/main/java/com/github/scribejava/core/httpclient/AbstractAsyncOnlyHttpClient.java
2. 	scribejava-core/src/main/java/com/github/scribejava/core/httpclient/HttpClient.java
3. 	scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
4. 	scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
5. 	scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuthService.java
6. 	scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClient.java


Usage:

```
service = new ServiceBuilder("bDjg0DxfxWnL43rC5zmwOyPLT")
       		.debug()
                .apiSecret("xxxxxxx")
                .build(TwitterApi.instance());
accessToken = new OAuth1AccessToken("xxxxxxxxxxxx", "xxxxxxxxx");

String boundary = "---just a boundary"; //any string, no restriction at all
request.addHeader("Content-Type","multipart/form-data; boundary=" + boundary);
request.setMultipartBoundary(boundary);
request.addMultipartPayload("form-data; name=\"media\"; filename=\"blob\"", "application/octet-stream", buffer, buffer.length);
//if there are more than one payload
request.addMultipartPayload("form-data; name=\"media\"; filename=\"blob\"", "application/octet-stream", buffer1, buffer1.length);

service.signRequest(accessToken, request);
final Response response = service.execute(request);

```

This has been tested with Twitter Media Upload API.
