### PR TITLE
Fix Fitbit token error extraction

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/fitbit/FitBitJsonTokenExtractor.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/fitbit/FitBitJsonTokenExtractor.java
@@ -1,12 +1,16 @@
 package com.github.scribejava.apis.fitbit;
 
 import com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor;
+import com.github.scribejava.core.model.OAuth2AccessTokenErrorResponse;
+
+import java.net.URI;
 import java.util.regex.Pattern;
 
 public class FitBitJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor {
 
     private static final Pattern USER_ID_REGEX_PATTERN = Pattern.compile("\"user_id\"\\s*:\\s*\"(\\S*?)\"");
-
+    private static final Pattern ERROR_REGEX_PATTERN = Pattern.compile("\"errorType\"\\s*:\\s*\"(\\S*?)\"");
+    private static final Pattern ERROR_DESCRIPTION_REGEX_PATTERN = Pattern.compile("\"message\"\\s*:\\s*\"([^\"]*?)\"");
     protected FitBitJsonTokenExtractor() {
     }
 
@@ -24,5 +28,22 @@ public class FitBitJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor {
             String refreshToken, String scope, String response) {
         return new FitBitOAuth2AccessToken(accessToken, tokenType, expiresIn, refreshToken, scope,
                 extractParameter(response, USER_ID_REGEX_PATTERN, false), response);
+    }
+
+    @Override
+    public void generateError(String response) {
+        final String errorInString = extractParameter(response, ERROR_REGEX_PATTERN, true);
+        final String errorDescription = extractParameter(response, ERROR_DESCRIPTION_REGEX_PATTERN, false);
+        final URI errorUri = URI.create("https://dev.fitbit.com/build/reference/web-api/oauth2/");
+
+        OAuth2AccessTokenErrorResponse.ErrorCode errorCode;
+        try {
+            errorCode = OAuth2AccessTokenErrorResponse.ErrorCode.valueOf(errorInString);
+        } catch (IllegalArgumentException iaE) {
+            //non oauth standard error code
+            errorCode = null;
+        }
+
+        throw new OAuth2AccessTokenErrorResponse(errorCode, errorDescription, errorUri, response);
     }
 }

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/fitbit/FitBitJsonTokenExtractorTest.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/fitbit/FitBitJsonTokenExtractorTest.java
@@ -1,0 +1,62 @@
+package com.github.scribejava.apis.fitbit;
+
+import com.github.scribejava.core.model.OAuth2AccessTokenErrorResponse;
+import com.github.scribejava.core.model.OAuth2AccessTokenErrorResponse.ErrorCode;
+
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class FitBitJsonTokenExtractorTest {
+
+    private static final String ERROR_DESCRIPTION = "Authorization code invalid: " +
+            "cbb1c11b23209011e89be71201fa6381464dc0af " +
+            "Visit https://dev.fitbit.com/docs/oauth2 for more information " +
+            "on the Fitbit Web API authorization process.";
+    private static final String ERROR_JSON = "{\"errors\":[{\"errorType\":\"invalid_grant\",\"message\":\"" +
+            ERROR_DESCRIPTION + "\"}],\"success\":false}";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testErrorExtraction() {
+
+        final FitBitJsonTokenExtractor extractor = new FitBitJsonTokenExtractor();
+
+        thrown.expect(OAuth2AccessTokenErrorResponse.class);
+        thrown.expect(errorCode(ErrorCode.invalid_grant));
+        thrown.expect(errorDescription(ERROR_DESCRIPTION));
+
+        extractor.generateError(ERROR_JSON);
+
+    }
+
+    private Matcher<OAuth2AccessTokenErrorResponse> errorCode(ErrorCode expected) {
+        return new FeatureMatcher<OAuth2AccessTokenErrorResponse, ErrorCode>(
+                equalTo(expected),
+                "a response with errorCode",
+                "errorCode") {
+            @Override
+            protected ErrorCode featureValueOf(OAuth2AccessTokenErrorResponse actual) {
+                return actual.getErrorCode();
+            }
+        };
+    }
+
+    private Matcher<OAuth2AccessTokenErrorResponse> errorDescription(String expected) {
+        return new FeatureMatcher<OAuth2AccessTokenErrorResponse, String>(
+                equalTo(expected),
+                "a response with errorDescription",
+                "errorDescription") {
+            @Override
+            protected String featureValueOf(OAuth2AccessTokenErrorResponse actual) {
+                return actual.getErrorDescription();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fitbit does not use a standard error response format, so the default extractor can't process the error code and description.

Sample Fitbit error:
```json
{
	"errors": [{
			"errorType": "invalid_grant",
			"message": "Authorization code invalid: cbb1c11b23209011e89be71201fa6381464dc0af Visit https://dev.fitbit.com/docs/oauth2 for more information on the Fitbit Web API authorization process."
		}
	],
	"success": false
}
```

Standard errors:
```json
{
       "error":"invalid_request",
       "error_description":"..."
}
```

Regarding the test: if it's not common practice to test the api project, we can leave it out.

