### PR TITLE
Fix Misfit access token error

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MisfitApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MisfitApi.java
@@ -1,5 +1,6 @@
 package com.github.scribejava.apis;
 
+import com.github.scribejava.core.builder.api.ClientAuthenticationType;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.builder.api.OAuth2SignatureType;
 
@@ -30,5 +31,10 @@ public class MisfitApi extends DefaultApi20 {
     @Override
     public OAuth2SignatureType getSignatureType() {
         return OAuth2SignatureType.BEARER_URI_QUERY_PARAMETER;
+    }
+
+    @Override
+    public ClientAuthenticationType getClientAuthenticationType() {
+        return ClientAuthenticationType.REQUEST_BODY;
     }
 }


### PR DESCRIPTION
When getAccessToken on MisfitApi, getting following error. I fixed it.

```
Exception in thread "main" com.github.scribejava.core.exceptions.OAuthException: Response body is incorrect. Can't extract a '"error"\s*:\s*"(\S*?)"' from this: 'Unauthorized'
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extractParameter(OAuth2AccessTokenJsonExtractor.java:107)
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.generateError(OAuth2AccessTokenJsonExtractor.java:57)
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extract(OAuth2AccessTokenJsonExtractor.java:46)
	at com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor.extract(OAuth2AccessTokenJsonExtractor.java:16)
	at com.github.scribejava.core.oauth.OAuth20Service.sendAccessTokenRequestSync(OAuth20Service.java:57)
	at com.github.scribejava.core.oauth.OAuth20Service.getAccessToken(OAuth20Service.java:93)
	at com.github.scribejava.core.oauth.OAuth20Service.getAccessToken(OAuth20Service.java:86)
	at com.github.scribejava.apis.examples.MisfitExample.main(MisfitExample.java:51)
```
