### PR TITLE
Add MediaWiki API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ScribeJava support out-of-box several HTTP clients:
 * Microsoft Azure Active Directory (Azure AD) (http://azure.microsoft.com/)
 * Microsoft Live (https://login.live.com/)
 * Mail.Ru (https://mail.ru/)
+* MediaWiki (https://www.mediawiki.org/)
 * Meetup (http://www.meetup.com/)
 * NAVER (http://www.naver.com/)
 * NetEase (http://www.163.com/)

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MediaWikiApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MediaWikiApi.java
@@ -1,0 +1,70 @@
+package com.github.scribejava.apis;
+
+import com.github.scribejava.core.builder.api.DefaultApi10a;
+
+public class MediaWikiApi extends DefaultApi10a {
+
+    private static final MediaWikiApi WIKIMEDIA_INSTANCE = new MediaWikiApi(
+        "https://meta.wikimedia.org/w/index.php",
+        "https://meta.wikimedia.org/wiki/"
+    );
+
+    private static final MediaWikiApi WIKIMEDIA_BETA_INSTANCE = new MediaWikiApi(
+        "https://meta.wikimedia.beta.wmflabs.org/w/index.php",
+        "https://meta.wikimedia.beta.wmflabs.org/wiki/"
+    );
+
+    private final String indexUrl;
+    private final String niceUrlBase;
+
+    /**
+     * @param indexUrl The URL to the index.php of the wiki.
+     * Due to <a href="https://phabricator.wikimedia.org/T59500">a MediaWiki bug</a>,
+     * some requests must currently use the non-nice URL.
+     * @param niceUrlBase The base of nice URLs for the wiki, including the trailing slash.
+     * Due to <a href="https://phabricator.wikimedia.org/T74186">another MediaWiki bug</a>,
+     * some requests must currently use the nice URL.
+     */
+    public MediaWikiApi(final String indexUrl, final String niceUrlBase) {
+        this.indexUrl = indexUrl;
+        this.niceUrlBase = niceUrlBase;
+    }
+
+    /**
+     * The instance for wikis hosted by the Wikimedia Foundation.
+     * Consumers are requested on
+     * <a href="https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose">
+     * Special:OAuthConsumerRegistration/propose
+     * </a>.
+     */
+    public static MediaWikiApi wikimediaInstance() {
+        return WIKIMEDIA_INSTANCE;
+    }
+
+    /**
+     * The instance for wikis in the Wikimedia Foundation’s Beta Cluster.
+     * Consumers are requested on
+     * <a href="https://meta.wikimedia.beta.wmflabs.org/wiki/Special:OAuthConsumerRegistration/propose">
+     * Special:OAuthConsumerRegistration/propose
+     * </a>.
+     */
+    public static MediaWikiApi wikimediaBetaInstance() {
+        return WIKIMEDIA_BETA_INSTANCE;
+    }
+
+    @Override
+    public String getRequestTokenEndpoint() {
+        return indexUrl + "?title=Special:OAuth/initiate";
+    }
+
+    @Override
+    public String getAuthorizationBaseUrl() {
+        return niceUrlBase + "Special:OAuth/authorize";
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return indexUrl + "?title=Special:OAuth/token";
+    }
+
+}

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/MediaWikiExample.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/MediaWikiExample.java
@@ -1,0 +1,70 @@
+package com.github.scribejava.apis.examples;
+
+import java.util.Scanner;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.apis.MediaWikiApi;
+import com.github.scribejava.core.model.OAuth1AccessToken;
+import com.github.scribejava.core.model.OAuth1RequestToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth10aService;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public final class MediaWikiExample {
+
+    // To get your consumer key/secret, see https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose
+    private static final String CONSUMER_KEY = "";
+    private static final String CONSUMER_SECRET = "";
+
+    private static final String API_USERINFO_URL =
+        "https://meta.wikimedia.org/w/api.php?action=query&format=json&meta=userinfo";
+
+    private MediaWikiExample() {
+    }
+
+    public static void main(String... args) throws IOException, InterruptedException, ExecutionException {
+        final OAuth10aService service = new ServiceBuilder(CONSUMER_KEY)
+                .apiSecret(CONSUMER_SECRET)
+                .build(MediaWikiApi.wikimediaInstance());
+
+        final Scanner in = new Scanner(System.in);
+
+        System.out.println("=== MediaWiki's OAuth Workflow ===");
+        System.out.println();
+
+        // Obtain the Request Token
+        System.out.println("Fetching the Request Token...");
+        final OAuth1RequestToken requestToken = service.getRequestToken();
+        System.out.println("Got the Request Token!");
+        System.out.println();
+
+        System.out.println("Now go and authorize ScribeJava here:");
+        System.out.println(service.getAuthorizationUrl(requestToken));
+        System.out.println("And paste the verifier here");
+        System.out.print(">>");
+        final String oauthVerifier = in.nextLine();
+        System.out.println();
+
+        // Trade the Request Token and Verfier for the Access Token
+        System.out.println("Trading the Request Token for an Access Token...");
+        final OAuth1AccessToken accessToken = service.getAccessToken(requestToken, oauthVerifier);
+        System.out.println("Got the Access Token!");
+        System.out.println("(The raw response looks like this: " + accessToken.getRawResponse() + "')");
+        System.out.println();
+
+        // Now let's go and ask for a protected resource!
+        System.out.println("Now we're going to access a protected resource...");
+        final OAuthRequest request = new OAuthRequest(Verb.GET, API_USERINFO_URL);
+        service.signRequest(accessToken, request);
+        final Response response = service.execute(request);
+        System.out.println("Got it! Lets see what we found...");
+        System.out.println();
+        System.out.println(response.getBody());
+
+        System.out.println();
+        System.out.println("Thats it man! Go and build something awesome with MediaWiki and ScribeJava! :)");
+    }
+
+}


### PR DESCRIPTION
Add MediaWiki API

This API can be used for any MediaWiki installation that has the [OAuth extension][1] installed. Two default instances are provided for convenience: one for wikis hosted by the Wikimedia Foundation (including Wikipedia), which is the one most users will be interested in, and one for the Wikimedia Foundation’s Beta Cluster, which is more appropriate for testing purposes.

The example is copied and slightly adapted from AWeberExample.java.

[1]: https://www.mediawiki.org/wiki/Extension:OAuth
