### PR TITLE
Issue #870 Avoid 'Cannot encode null object' when omitting callback url

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -108,7 +108,10 @@ public class OAuth20Service extends OAuthService {
         api.getClientAuthentication().addClientAuthentication(request, getApiKey(), getApiSecret());
 
         request.addParameter(OAuthConstants.CODE, code);
-        request.addParameter(OAuthConstants.REDIRECT_URI, getCallback());
+        String callback = getCallback();
+        if (callback != null) {
+            request.addParameter(OAuthConstants.REDIRECT_URI, callback);
+        }
         final String scope = getScope();
         if (scope != null) {
             request.addParameter(OAuthConstants.SCOPE, scope);


### PR DESCRIPTION
If callback url is not set aquireing access token fails with
```
java.lang.IllegalArgumentException: Cannot encode null object
	at com.github.scribejava.core.utils.Preconditions.check(Preconditions.java:49)
	at com.github.scribejava.core.utils.Preconditions.checkNotNull(Preconditions.java:19)
	at com.github.scribejava.core.utils.OAuthEncoder.encode(OAuthEncoder.java:26)
	at com.github.scribejava.core.model.Parameter.asUrlEncodedPair(Parameter.java:16)
	at com.github.scribejava.core.model.ParameterList.asFormUrlEncodedString(ParameterList.java:63)
	at com.github.scribejava.core.model.OAuthRequest.getByteArrayPayload(OAuthRequest.java:232)
	at com.github.scribejava.core.oauth.OAuthService.execute(OAuthService.java:127)
	at com.github.scribejava.core.oauth.OAuth20Service.sendAccessTokenRequestSync(OAuth20Service.java:57)
	at com.github.scribejava.core.oauth.OAuth20Service.getAccessToken(OAuth20Service.java:93)
	at com.github.scribejava.core.oauth.OAuth20Service.getAccessToken(OAuth20Service.java:86)
```