### PR TITLE
Fix and extend Multipart functionality of JDK Http Client

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
@@ -195,11 +195,15 @@ public class JDKHttpClient implements HttpClient {
 
         final int contentLength = multipartPayload.getContentLength();
         if (requiresBody || contentLength > 0) {
+            connection.setRequestProperty(CONTENT_TYPE,
+                    "multipart/" + multipartPayload.getSubtype() + "; boundary=" + multipartPayload.getBoundary());
             final OutputStream os = prepareConnectionForBodyAndGetOutputStream(connection, contentLength);
 
             for (BodyPartPayload bodyPart : multipartPayload.getBodyParts()) {
                 os.write(multipartPayload.getStartBoundary(bodyPart));
                 os.write(bodyPart.getPayload());
+            }
+            if (!multipartPayload.getBodyParts().isEmpty()) {
                 os.write(multipartPayload.getEndBoundary());
             }
         }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
@@ -128,32 +128,61 @@ public class OAuthRequest {
     }
 
     /**
-     * Set boundary of multipart request
+     * Set subtype and boundary of multipart request
      *
-     * @param boundary can be any string
+     * @param subtype subtype of multipart content-type
+     * @param boundary can be any string between 1 and 70 characters long using alphanumeric characters and any of
+     *  "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?" / " ", but must not end with white space
      */
-    public void initMultipartBoundary(String boundary) {
-        multipartPayload = new MultipartPayload(boundary == null
-                ? Long.toString(System.currentTimeMillis())
+    public void initMultipartPayload(String subtype, String boundary) {
+        multipartPayload = new MultipartPayload(subtype == null ? "mixed" : subtype, boundary == null
+                ? "---------------------------" + Long.toString(System.currentTimeMillis())
                 : boundary);
     }
 
     /**
-     * init boundary of multipart request with default boundary
+     * Init multipart request with given subtype and default boundary
+     *
+     * @param subtype subtype of multipart content-type
      */
-    public void initMultipartBoundary() {
-        initMultipartBoundary(null);
+    public void initMultipartPayload(String subtype) {
+        initMultipartPayload(subtype, null);
     }
 
     /**
-     * you can invoke {@link #initMultipartBoundary(java.lang.String) } to set custom boundary
+     * Init multipart request with default values for subtype and boundary
+     */
+    public void initMultipartPayload() {
+        initMultipartPayload(null, null);
+    }
+
+    /**
+     * Init multipart request with given boundary and default subtype
+     *
+     * @param boundary can be any string between 1 and 70 characters long using alphanumeric characters and any of
+     *  "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?" / " ", but must not end with white space
+     */
+    public void initMultipartBoundary(String boundary) {
+        initMultipartPayload(null, boundary);
+    }
+
+    /**
+     * Init multipart request with default values for subtype and boundary
+     */
+    public void initMultipartBoundary() {
+        initMultipartPayload(null, null);
+    }
+
+    /**
+     * Can invoke {@link #initMultipartBoundary(java.lang.String)} to set custom boundary
+     * or {@link #initMultipartPayload(java.lang.String, java.lang.String)} to set subtype and boundary
      * @param contentDisposition contentDisposition
      * @param contentType contentType
      * @param payload payload
      */
     public void addMultipartPayload(String contentDisposition, String contentType, byte[] payload) {
         if (multipartPayload == null) {
-            initMultipartBoundary();
+            initMultipartPayload();
         }
         multipartPayload.addMultipartPayload(contentDisposition, contentType, payload);
     }


### PR DESCRIPTION
Hi,

I tried to use the Multipart functionality that was recently added to the `JDKHttpClient`. I specifically wanted to create a `multipart/form-data` request including files. But I found it had problems with both the headers as well as the body, but with this PR it works now.

First of all the Content-Type header was not specifically set by the `JDKHttpClient` for a Multipart request, so the method `prepareConnectionForBodyAndGetOutputStream` would always default to `application/x-www-form-urlencoded`. Moreover it was not possible to specify a Multipart subtype, which I also tried to fix with this PR.

The body was also wrong: the `getStartBoundary` didn't start with a CRLF, and the `getEndBoundary` was used after every BodyPart instead of only at the end.

I tried to keep it backward compatible by introducing a new method `initMultipartPayload` alongside the existing `initMultipartBoundary` in the `OAuthRequest`.

Thanks for looking into this! Please let me know if you have any feedback!