### PR TITLE
Added an OpenIdTokenExtractor to MicrosoftAzureActiveDirectory20Api

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
@@ -2,6 +2,9 @@ package com.github.scribejava.apis;
 
 import com.github.scribejava.apis.microsoftazureactivedirectory.BaseMicrosoftAzureActiveDirectoryApi;
 import com.github.scribejava.apis.microsoftazureactivedirectory.MicrosoftAzureActiveDirectory20BearerSignature;
+import com.github.scribejava.apis.openid.OpenIdJsonTokenExtractor;
+import com.github.scribejava.core.extractors.TokenExtractor;
+import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.oauth2.bearersignature.BearerSignature;
 
 /**
@@ -39,6 +42,11 @@ public class MicrosoftAzureActiveDirectory20Api extends BaseMicrosoftAzureActive
     @Override
     public BearerSignature getBearerSignature() {
         return MicrosoftAzureActiveDirectory20BearerSignature.instance();
+    }
+
+    @Override
+    public TokenExtractor<OAuth2AccessToken> getAccessTokenExtractor() {
+        return OpenIdJsonTokenExtractor.instance();
     }
 
     @Override


### PR DESCRIPTION
Since the AD 2.0 API is OpenId compliant, this allows users to extract OpenId information when the scope is granted. This is inline with the Google and StackExchange APIs.