### PR TITLE
extend error codes with invalid_token

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuth2AccessTokenErrorResponse.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuth2AccessTokenErrorResponse.java
@@ -15,6 +15,7 @@ public class OAuth2AccessTokenErrorResponse extends OAuthException {
         INVALID_REQUEST("invalid_request"),
         INVALID_CLIENT("invalid_client"),
         INVALID_GRANT("invalid_grant"),
+        INVALID_TOKEN("invalid_token"),
         UNAUTHORIZED_CLIENT("unauthorized_client"),
         UNSUPPORTED_GRANT_TYPE("unsupported_grant_type"),
         INVALID_SCOPE("invalid_scope"),


### PR DESCRIPTION
according to RFC6750 Section 6.2.2 error extension
see https://tools.ietf.org/html/rfc6750#section-6.2.2

makes devs live bit easier handling errors via spring-security-oauth, 
see https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2Exception.java

