### PR TITLE
Use proper Authentication for keycloak

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
@@ -4,6 +4,8 @@ import com.github.scribejava.apis.openid.OpenIdJsonTokenExtractor;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.extractors.TokenExtractor;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.oauth2.clientauthentication.ClientAuthentication;
+import com.github.scribejava.core.oauth2.clientauthentication.RequestBodyAuthenticationScheme;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -59,5 +61,10 @@ public class KeycloakApi extends DefaultApi20 {
     @Override
     public String getRevokeTokenEndpoint() {
         throw new RuntimeException("Not implemented yet");
+    }
+
+    @Override
+    public ClientAuthentication getClientAuthentication() {
+        return RequestBodyAuthenticationScheme.instance();
     }
 }


### PR DESCRIPTION
I believe, `RequestBodyAuthenticationScheme` is the proper type of authentication, but not `HttpBasicAuthenticationScheme` one. At least, it doesn't give error anymore