### PR TITLE
Add debug output to OAuth2Service

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/FacebookApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/FacebookApi.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.facebook.FacebookAccessTokenJsonExtractor;
 import com.github.scribejava.apis.facebook.FacebookService;
 import com.github.scribejava.core.builder.api.DefaultApi20;
@@ -71,8 +73,9 @@ public class FacebookApi extends DefaultApi20 {
 
     @Override
     public FacebookService createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new FacebookService(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new FacebookService(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 }

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/ImgurApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/ImgurApi.java
@@ -6,6 +6,8 @@ import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.httpclient.HttpClientConfig;
 import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.model.ParameterList;
+
+import java.io.OutputStream;
 import java.util.Map;
 
 public class ImgurApi extends DefaultApi20 {
@@ -55,9 +57,10 @@ public class ImgurApi extends DefaultApi20 {
 
     @Override
     public ImgurOAuthService createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new ImgurOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new ImgurOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 
     public static boolean isOob(String callback) {

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MailruApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MailruApi.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.mailru.MailruOAuthService;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.httpclient.HttpClient;
@@ -30,8 +32,9 @@ public class MailruApi extends DefaultApi20 {
 
     @Override
     public MailruOAuthService createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new MailruOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new MailruOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 }

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/OdnoklassnikiApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/OdnoklassnikiApi.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.odnoklassniki.OdnoklassnikiOAuthService;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.httpclient.HttpClient;
@@ -34,10 +36,10 @@ public class OdnoklassnikiApi extends DefaultApi20 {
 
     @Override
     public OdnoklassnikiOAuthService createService(String apiKey, String apiSecret, String callback,
-            String defaultScope, String responseType, String userAgent, HttpClientConfig httpClientConfig,
-            HttpClient httpClient) {
-        return new OdnoklassnikiOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String defaultScope, String responseType, OutputStream debugStream, String userAgent,
+            HttpClientConfig httpClientConfig, HttpClient httpClient) {
+        return new OdnoklassnikiOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/WunderlistAPI.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/WunderlistAPI.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.wunderlist.WunderlistOAuthService;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.httpclient.HttpClient;
@@ -49,8 +51,9 @@ public class WunderlistAPI extends DefaultApi20 {
 
     @Override
     public OAuth20Service createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new WunderlistOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new WunderlistOAuthService(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 }

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/facebook/FacebookService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/facebook/FacebookService.java
@@ -5,6 +5,8 @@ import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.httpclient.HttpClientConfig;
 import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.oauth.OAuth20Service;
+
+import java.io.OutputStream;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Formatter;
@@ -14,8 +16,10 @@ import javax.crypto.spec.SecretKeySpec;
 public class FacebookService extends OAuth20Service {
 
     public FacebookService(DefaultApi20 api, String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/imgur/ImgurOAuthService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/imgur/ImgurOAuthService.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis.imgur;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.ImgurApi;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.httpclient.HttpClient;
@@ -13,8 +15,10 @@ import com.github.scribejava.core.pkce.PKCE;
 public class ImgurOAuthService extends OAuth20Service {
 
     public ImgurOAuthService(DefaultApi20 api, String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/mailru/MailruOAuthService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/mailru/MailruOAuthService.java
@@ -8,6 +8,8 @@ import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.httpclient.HttpClientConfig;
 import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.oauth.OAuth20Service;
+
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
@@ -17,8 +19,10 @@ import java.util.Formatter;
 public class MailruOAuthService extends OAuth20Service {
 
     public MailruOAuthService(DefaultApi20 api, String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiOAuthService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiOAuthService.java
@@ -7,6 +7,8 @@ import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.model.Parameter;
 import com.github.scribejava.core.model.ParameterList;
 import com.github.scribejava.core.oauth.OAuth20Service;
+
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 
 import java.net.URLDecoder;
@@ -20,9 +22,10 @@ import java.util.List;
 public class OdnoklassnikiOAuthService extends OAuth20Service {
 
     public OdnoklassnikiOAuthService(DefaultApi20 api, String apiKey, String apiSecret, String callback,
-            String defaultScope, String responseType, String userAgent, HttpClientConfig httpClientConfig,
-            HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String defaultScope, String responseType, OutputStream debugStream, String userAgent,
+            HttpClientConfig httpClientConfig, HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/wunderlist/WunderlistOAuthService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/wunderlist/WunderlistOAuthService.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.apis.wunderlist;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.apis.WunderlistAPI;
 import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.httpclient.HttpClientConfig;
@@ -9,9 +11,10 @@ import com.github.scribejava.core.oauth.OAuth20Service;
 public class WunderlistOAuthService extends OAuth20Service {
 
     public WunderlistOAuthService(WunderlistAPI api, String apiKey, String apiSecret, String callback,
-            String defaultScope, String responseType, String userAgent, HttpClientConfig httpClientConfig,
-            HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String defaultScope, String responseType, OutputStream debugStream, String userAgent,
+            HttpClientConfig httpClientConfig, HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override

--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilder.java
@@ -68,7 +68,7 @@ public class ServiceBuilder implements ServiceBuilderOAuth10a, ServiceBuilderOAu
     }
 
     @Override
-    public ServiceBuilderOAuth10a debugStream(OutputStream debugStream) {
+    public ServiceBuilder debugStream(OutputStream debugStream) {
         Preconditions.checkNotNull(debugStream, "debug stream can't be null");
         this.debugStream = debugStream;
         return this;
@@ -101,7 +101,7 @@ public class ServiceBuilder implements ServiceBuilderOAuth10a, ServiceBuilderOAu
     }
 
     @Override
-    public ServiceBuilderOAuth10a debug() {
+    public ServiceBuilder debug() {
         return debugStream(System.out);
     }
 
@@ -113,7 +113,7 @@ public class ServiceBuilder implements ServiceBuilderOAuth10a, ServiceBuilderOAu
 
     @Override
     public OAuth20Service build(DefaultApi20 api) {
-        return api.createService(apiKey, apiSecret, callback, scope, responseType, userAgent, httpClientConfig,
-                httpClient);
+        return api.createService(apiKey, apiSecret, callback, scope, responseType, debugStream, userAgent,
+                httpClientConfig, httpClient);
     }
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/api/DefaultApi20.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/api/DefaultApi20.java
@@ -13,6 +13,8 @@ import com.github.scribejava.core.oauth2.bearersignature.BearerSignature;
 import com.github.scribejava.core.oauth2.bearersignature.BearerSignatureAuthorizationRequestHeaderField;
 import com.github.scribejava.core.oauth2.clientauthentication.ClientAuthentication;
 import com.github.scribejava.core.oauth2.clientauthentication.HttpBasicAuthenticationScheme;
+
+import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -106,8 +108,9 @@ public abstract class DefaultApi20 {
     }
 
     public OAuth20Service createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new OAuth20Service(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new OAuth20Service(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent,
                 httpClientConfig, httpClient);
     }
 

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java
@@ -22,14 +22,12 @@ import java.util.concurrent.ExecutionException;
 public class OAuth10aService extends OAuthService {
 
     private static final String VERSION = "1.0";
-    private final OutputStream debugStream;
     private final DefaultApi10a api;
     private final String scope;
 
     public OAuth10aService(DefaultApi10a api, String apiKey, String apiSecret, String callback, String scope,
             OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(apiKey, apiSecret, callback, userAgent, httpClientConfig, httpClient);
-        this.debugStream = debugStream;
+        super(apiKey, apiSecret, callback, debugStream, userAgent, httpClientConfig, httpClient);
         this.api = api;
         this.scope = scope;
     }
@@ -191,16 +189,5 @@ public class OAuth10aService extends OAuthService {
 
     public DefaultApi10a getApi() {
         return api;
-    }
-
-    public void log(String messagePattern, Object... params) {
-        if (debugStream != null) {
-            final String message = String.format(messagePattern, params) + '\n';
-            try {
-                debugStream.write(message.getBytes("UTF8"));
-            } catch (IOException | RuntimeException e) {
-                throw new RuntimeException("there were problems while writting to the debug stream", e);
-            }
-        }
     }
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -1,6 +1,7 @@
 package com.github.scribejava.core.oauth;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.concurrent.Future;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor;
@@ -28,8 +29,9 @@ public class OAuth20Service extends OAuthService {
     private final String defaultScope;
 
     public OAuth20Service(DefaultApi20 api, String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(apiKey, apiSecret, callback, userAgent, httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        super(apiKey, apiSecret, callback, debugStream, userAgent, httpClientConfig, httpClient);
         this.responseType = responseType;
         this.api = api;
         this.defaultScope = defaultScope;

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -132,8 +132,9 @@ public class OAuth20Service extends OAuthService {
             request.addParameter(PKCE.PKCE_CODE_VERIFIER_PARAM, pkceCodeVerifier);
         }
 
-        log("created access token request with body params [%s], query string params [%s]", request.getBodyParams(),
-                request.getQueryStringParams());
+        log("created access token request with body params [%s], query string params [%s]",
+                request.getBodyParams().asFormUrlEncodedString(),
+                request.getQueryStringParams().asFormUrlEncodedString());
         return request;
     }
 
@@ -190,8 +191,9 @@ public class OAuth20Service extends OAuthService {
         request.addParameter(OAuthConstants.REFRESH_TOKEN, refreshToken);
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.REFRESH_TOKEN);
 
-        log("created refresh token request with body params [%s], query string params [%s]", request.getBodyParams(),
-                request.getQueryStringParams());
+        log("created refresh token request with body params [%s], query string params [%s]",
+                request.getBodyParams().asFormUrlEncodedString(),
+                request.getQueryStringParams().asFormUrlEncodedString());
 
         return request;
     }
@@ -257,7 +259,8 @@ public class OAuth20Service extends OAuthService {
         api.getClientAuthentication().addClientAuthentication(request, getApiKey(), getApiSecret());
 
         log("created access token password grant request with body params [%s], query string params [%s]",
-                request.getBodyParams(), request.getQueryStringParams());
+                request.getBodyParams().asFormUrlEncodedString(),
+                request.getQueryStringParams().asFormUrlEncodedString());
 
         return request;
     }
@@ -318,7 +321,8 @@ public class OAuth20Service extends OAuthService {
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.CLIENT_CREDENTIALS);
 
         log("created access token client credentials grant request with body params [%s], query string params [%s]",
-                request.getBodyParams(), request.getQueryStringParams());
+                request.getBodyParams().asFormUrlEncodedString(),
+                request.getQueryStringParams().asFormUrlEncodedString());
 
         return request;
     }
@@ -390,8 +394,9 @@ public class OAuth20Service extends OAuthService {
             request.addParameter("token_type_hint", tokenTypeHint.getValue());
         }
 
-        log("created revoke token request with body params [%s], query string params [%s]", request.getBodyParams(),
-                request.getQueryStringParams());
+        log("created revoke token request with body params [%s], query string params [%s]",
+                request.getBodyParams().asFormUrlEncodedString(),
+                request.getQueryStringParams().asFormUrlEncodedString());
 
         return request;
     }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -40,7 +40,15 @@ public class OAuth20Service extends OAuthService {
     //protected to facilitate mocking
     protected OAuth2AccessToken sendAccessTokenRequestSync(OAuthRequest request)
             throws IOException, InterruptedException, ExecutionException {
-        return api.getAccessTokenExtractor().extract(execute(request));
+        log("send request for access token synchronously to %s", request.getCompleteUrl());
+
+        final Response response = execute(request);
+        final String body = response.getBody();
+
+        log("response status code: %s", response.getCode());
+        log("response body: %s", body);
+
+        return api.getAccessTokenExtractor().extract(response);
     }
 
     //protected to facilitate mocking
@@ -51,10 +59,16 @@ public class OAuth20Service extends OAuthService {
     //protected to facilitate mocking
     protected Future<OAuth2AccessToken> sendAccessTokenRequestAsync(OAuthRequest request,
             OAuthAsyncRequestCallback<OAuth2AccessToken> callback) {
+        log("send request for access token asynchronously to %s", request.getCompleteUrl());
 
         return execute(request, callback, new OAuthRequest.ResponseConverter<OAuth2AccessToken>() {
             @Override
             public OAuth2AccessToken convert(Response response) throws IOException {
+                log("received response for access token");
+                final String body = response.getBody();
+
+                log("response status code: %s", response.getCode());
+                log("response body: %s", body);
                 return getApi().getAccessTokenExtractor().extract(response);
             }
         });
@@ -117,6 +131,9 @@ public class OAuth20Service extends OAuthService {
         if (pkceCodeVerifier != null) {
             request.addParameter(PKCE.PKCE_CODE_VERIFIER_PARAM, pkceCodeVerifier);
         }
+
+        log("created access token request with body params [%s], query string params [%s]", request.getBodyParams(),
+                request.getQueryStringParams());
         return request;
     }
 
@@ -172,6 +189,10 @@ public class OAuth20Service extends OAuthService {
 
         request.addParameter(OAuthConstants.REFRESH_TOKEN, refreshToken);
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.REFRESH_TOKEN);
+
+        log("created refresh token request with body params [%s], query string params [%s]", request.getBodyParams(),
+                request.getQueryStringParams());
+
         return request;
     }
 
@@ -235,6 +256,9 @@ public class OAuth20Service extends OAuthService {
 
         api.getClientAuthentication().addClientAuthentication(request, getApiKey(), getApiSecret());
 
+        log("created access token password grant request with body params [%s], query string params [%s]",
+                request.getBodyParams(), request.getQueryStringParams());
+
         return request;
     }
 
@@ -292,6 +316,10 @@ public class OAuth20Service extends OAuthService {
             request.addParameter(OAuthConstants.SCOPE, defaultScope);
         }
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.CLIENT_CREDENTIALS);
+
+        log("created access token client credentials grant request with body params [%s], query string params [%s]",
+                request.getBodyParams(), request.getQueryStringParams());
+
         return request;
     }
 
@@ -361,6 +389,10 @@ public class OAuth20Service extends OAuthService {
         if (tokenTypeHint != null) {
             request.addParameter("token_type_hint", tokenTypeHint.getValue());
         }
+
+        log("created revoke token request with body params [%s], query string params [%s]", request.getBodyParams(),
+                request.getQueryStringParams());
+
         return request;
     }
 

--- a/scribejava-core/src/test/java/com/github/scribejava/core/AbstractClientTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/AbstractClientTest.java
@@ -44,7 +44,8 @@ public abstract class AbstractClientTest {
 
     @Before
     public void setUp() {
-        oAuthService = new OAuth20Service(null, "test", "test", null, null, null, null, null, createNewClient());
+        oAuthService = new OAuth20Service(null, "test", "test", null, null, null, System.out, null, null,
+                createNewClient());
     }
 
     @After

--- a/scribejava-core/src/test/java/com/github/scribejava/core/oauth/OAuth20ApiUnit.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/oauth/OAuth20ApiUnit.java
@@ -1,5 +1,7 @@
 package com.github.scribejava.core.oauth;
 
+import java.io.OutputStream;
+
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.httpclient.HttpClient;
 import com.github.scribejava.core.httpclient.HttpClientConfig;
@@ -20,9 +22,10 @@ class OAuth20ApiUnit extends DefaultApi20 {
 
     @Override
     public OAuth20ServiceUnit createService(String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        return new OAuth20ServiceUnit(this, apiKey, apiSecret, callback, defaultScope, responseType, userAgent,
-                httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        return new OAuth20ServiceUnit(this, apiKey, apiSecret, callback, defaultScope, responseType, debugStream,
+                userAgent, httpClientConfig, httpClient);
     }
 
     @Override

--- a/scribejava-core/src/test/java/com/github/scribejava/core/oauth/OAuth20ServiceUnit.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/oauth/OAuth20ServiceUnit.java
@@ -11,6 +11,7 @@ import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.model.Parameter;
 
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -23,8 +24,10 @@ class OAuth20ServiceUnit extends OAuth20Service {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     OAuth20ServiceUnit(DefaultApi20 api, String apiKey, String apiSecret, String callback, String defaultScope,
-            String responseType, String userAgent, HttpClientConfig httpClientConfig, HttpClient httpClient) {
-        super(api, apiKey, apiSecret, callback, defaultScope, responseType, userAgent, httpClientConfig, httpClient);
+            String responseType, OutputStream debugStream, String userAgent, HttpClientConfig httpClientConfig,
+            HttpClient httpClient) {
+        super(api, apiKey, apiSecret, callback, defaultScope, responseType, debugStream, userAgent, httpClientConfig,
+                httpClient);
     }
 
     @Override


### PR DESCRIPTION
I pulled up the `debugStream` field into `OAuthService` so that both `OAuth10aService` and `OAuth20Service` can provide debug output. I also added log messages to the `OAuth20Service` when different requestz are created and sent, both for the sync and async case.

To print `ParameterList` objects, I used the `asFormUrlEncodedString()` method because that was already there, knowing that the output format might not always be what you want.

Please let me know if there is anything you want me to change or add.

Thank you!