### PR TITLE
Build OAuth10a service from ServiceBuilderOAuth10a

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilderOAuth10a.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/builder/ServiceBuilderOAuth10a.java
@@ -9,22 +9,22 @@ import java.io.OutputStream;
 public interface ServiceBuilderOAuth10a extends ServiceBuilderCommon {
 
     @Override
-    ServiceBuilderOAuth20 callback(String callback);
+    ServiceBuilderOAuth10a callback(String callback);
 
     @Override
-    ServiceBuilderOAuth20 apiKey(String apiKey);
+    ServiceBuilderOAuth10a apiKey(String apiKey);
 
     @Override
-    ServiceBuilderOAuth20 apiSecret(String apiSecret);
+    ServiceBuilderOAuth10a apiSecret(String apiSecret);
 
     @Override
-    ServiceBuilderOAuth20 httpClientConfig(HttpClientConfig httpClientConfig);
+    ServiceBuilderOAuth10a httpClientConfig(HttpClientConfig httpClientConfig);
 
     @Override
-    ServiceBuilderOAuth20 httpClient(HttpClient httpClient);
+    ServiceBuilderOAuth10a httpClient(HttpClient httpClient);
 
     @Override
-    ServiceBuilderOAuth20 userAgent(String userAgent);
+    ServiceBuilderOAuth10a userAgent(String userAgent);
 
     ServiceBuilderOAuth10a debugStream(OutputStream debugStream);
 


### PR DESCRIPTION
I suspect this is a typo, but it seems like the ServiceBuilderOAuth10a is building ServiceBuilderOAuth20. Looking at ServiceBuilder, it passes these parameters into the DefaultApi10a and DefaultApi20's createService method, so it seems like this should be allowed for OAuth10a services as well.

Not sure how this is best tested given your setup; let me know how I can best add tests to this PR.