### PR TITLE
pom.xml: specify Maven Central repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>org.source.repo</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Otherwise dependencies cannot be resolved, unless they are cached locally.