### PR TITLE
Http headers QoL changes

### DIFF
--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
@@ -101,6 +101,15 @@ public class OAuthRequest {
     }
 
     /**
+     * Add a collection of HTTP Headers to the Request.
+     *
+     * @param headers a key-value map of HTTP headers
+     */
+    public void addHeaders(Map<String, String> headers) {
+        this.headers.putAll(headers);
+    }
+
+    /**
      * Add a body Parameter (for POST/ PUT Requests)
      *
      * @param key the parameter name

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthRequest.java
@@ -9,6 +9,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -70,7 +71,7 @@ public class OAuthRequest {
     }
 
     public Map<String, String> getOauthParameters() {
-        return oauthParameters;
+        return Collections.unmodifiableMap(oauthParameters);
     }
 
     public void setRealm(String realm) {
@@ -391,7 +392,7 @@ public class OAuthRequest {
     }
 
     public Map<String, String> getHeaders() {
-        return headers;
+        return Collections.unmodifiableMap(headers);
     }
 
     public String getCharset() {

--- a/scribejava-core/src/test/java/com/github/scribejava/core/model/OAuthRequestTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/model/OAuthRequestTest.java
@@ -1,9 +1,13 @@
 package com.github.scribejava.core.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class OAuthRequestTest {
 
@@ -46,5 +50,13 @@ public class OAuthRequestTest {
         assertEquals("last", request.getHeaders().get("HEADER-NAME"));
         assertEquals("last", request.getHeaders().get("header-name"));
         assertEquals("last", request.getHeaders().get("Header-Name"));
+    }
+    @Test
+    public void shouldAddMultipleHeaders() {
+        final Map<String, String> dummyHeaderMap = new HashMap<>(2);
+        dummyHeaderMap.put("key1", "value1");
+        dummyHeaderMap.put("key2", "value2");
+        request.addHeaders(dummyHeaderMap);
+        assertEquals(2L, request.getHeaders().size());
     }
 }

--- a/scribejava-core/src/test/java/com/github/scribejava/core/model/OAuthRequestTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/model/OAuthRequestTest.java
@@ -51,6 +51,17 @@ public class OAuthRequestTest {
         assertEquals("last", request.getHeaders().get("header-name"));
         assertEquals("last", request.getHeaders().get("Header-Name"));
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldEnforceImmutableHeaders() {
+        request.getHeaders().put("dummyKey", "dummyValue");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldEnforceImmutableOauthParameters() {
+        request.getOauthParameters().put("dummyKey", "dummyValue");
+    }
+
     @Test
     public void shouldAddMultipleHeaders() {
         final Map<String, String> dummyHeaderMap = new HashMap<>(2);


### PR DESCRIPTION
This PR adds a quality of life change, that allows to add a map of HTTP headers at once.
It also properly encapsulates the Headers and Parameters maps of the OAuthRequest to not leak mutable collections.