### PR TITLE
Fixes for use with Microsoft Graph

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
@@ -43,6 +43,7 @@ public class MicrosoftAzureActiveDirectory20Api extends BaseMicrosoftAzureActive
 
     @Override
     protected String getEndpointVersionPath() {
-        return "/v2.0";
+        return "";
     }
+    
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/httpclient/jdk/JDKHttpClient.java
@@ -189,6 +189,7 @@ public class JDKHttpClient implements HttpClient {
     }
 
     private static void addBody(HttpURLConnection connection, byte[] content, boolean requiresBody) throws IOException {
+    	if (!requiresBody && content==null) return;
         final int contentLength = content.length;
         if (requiresBody || contentLength > 0) {
             final OutputStream outputStream = prepareConnectionForBodyAndGetOutputStream(connection, contentLength);

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth20Service.java
@@ -330,6 +330,8 @@ public class OAuth20Service extends OAuthService {
         }
         request.addParameter(OAuthConstants.GRANT_TYPE, OAuthConstants.CLIENT_CREDENTIALS);
 
+        request.addParameter("resource", "https://graph.microsoft.com"); // necessary for correct audience claim
+        
         if (isDebug()) {
             log("created access token client credentials grant request with body params [%s], query string params [%s]",
                     request.getBodyParams().asFormUrlEncodedString(),


### PR DESCRIPTION
With these changes, it is possible to use Microsoft Graph to upload/convert/delete a file, following https://medium.com/medialesson/convert-files-to-pdf-using-microsoft-graph-azure-functions-20bc84d2adc4

getAccessTokenEndpoint = MSFT_LOGIN_URL + tenant + OAUTH_2 + getEndpointVersionPath() + "/token";

For it to work for me, I have to have an empty EndpointVersionPath.

It is also necessary to pass a resource, to get the audience claim correct.   I have hard coded this, but if you process this PR, you'll want to handle this differently.

