### PR TITLE
Created RFC7523 JWT client auth

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ScribeJava support out-of-box several HTTP clients:
   * [RFC 7636](https://tools.ietf.org/html/rfc7636) Proof Key for Code Exchange by OAuth Public Clients (PKCE), [example](https://github.com/scribejava/scribejava/blob/master/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/Google20WithPKCEExample.java)
   * [RFC 7009](https://tools.ietf.org/html/rfc7009) OAuth 2.0 Token Revocation, [example](https://github.com/scribejava/scribejava/blob/master/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/Google20RevokeExample.java)
   * [RFC 5849](https://tools.ietf.org/html/rfc5849) The OAuth 1.0 Protocol, [example](https://github.com/scribejava/scribejava/blob/master/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/TwitterExample.java)
+  * [RFC rfc7523](https://tools.ietf.org/html/rfc7523) JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants, [example](https://github.com/scribejava/scribejava/blob/master/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java)
 
 ### Supports all (50+) major 1.0a and 2.0 OAuth APIs out-of-the-box
 

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
@@ -75,7 +75,7 @@ public class KeycloakApi extends DefaultApi20 {
 
     @Override
     public ClientAuthentication getClientAuthentication() {
-        if(this.keyId != null && this.privateKey != null) {
+        if (this.keyId != null && this.privateKey != null) {
             return JWTAuthenticationScheme.instance(privateKey, baseUrlWithRealm, keyId);
         }
         return HttpBasicAuthenticationScheme.instance();

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/KeycloakApi.java
@@ -4,7 +4,11 @@ import com.github.scribejava.apis.openid.OpenIdJsonTokenExtractor;
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.extractors.TokenExtractor;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.oauth2.clientauthentication.ClientAuthentication;
+import com.github.scribejava.core.oauth2.clientauthentication.HttpBasicAuthenticationScheme;
+import com.github.scribejava.core.oauth2.clientauthentication.JWTAuthenticationScheme;
 
+import java.security.interfaces.RSAPrivateKey;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -13,9 +17,13 @@ public class KeycloakApi extends DefaultApi20 {
     private static final ConcurrentMap<String, KeycloakApi> INSTANCES = new ConcurrentHashMap<>();
 
     private final String baseUrlWithRealm;
+    private final RSAPrivateKey privateKey;
+    private final String keyId;
 
-    protected KeycloakApi(String baseUrlWithRealm) {
+    protected KeycloakApi(String baseUrlWithRealm, RSAPrivateKey privateKey, String keyId) {
         this.baseUrlWithRealm = baseUrlWithRealm;
+        this.privateKey = privateKey;
+        this.keyId = keyId;
     }
 
     public static KeycloakApi instance() {
@@ -23,12 +31,16 @@ public class KeycloakApi extends DefaultApi20 {
     }
 
     public static KeycloakApi instance(String baseUrl, String realm) {
+        return instance(baseUrl, realm, null, null);
+    }
+
+    public static KeycloakApi instance(String baseUrl, String realm, RSAPrivateKey privateKey, String keyId) {
         final String defaultBaseUrlWithRealm = composeBaseUrlWithRealm(baseUrl, realm);
 
         //java8: switch to ConcurrentMap::computeIfAbsent
         KeycloakApi api = INSTANCES.get(defaultBaseUrlWithRealm);
         if (api == null) {
-            api = new KeycloakApi(defaultBaseUrlWithRealm);
+            api = new KeycloakApi(defaultBaseUrlWithRealm, privateKey, keyId);
             final KeycloakApi alreadyCreatedApi = INSTANCES.putIfAbsent(defaultBaseUrlWithRealm, api);
             if (alreadyCreatedApi != null) {
                 return alreadyCreatedApi;
@@ -59,5 +71,13 @@ public class KeycloakApi extends DefaultApi20 {
     @Override
     public String getRevokeTokenEndpoint() {
         throw new RuntimeException("Not implemented yet");
+    }
+
+    @Override
+    public ClientAuthentication getClientAuthentication() {
+        if(this.keyId != null && this.privateKey != null) {
+            return JWTAuthenticationScheme.instance(privateKey, baseUrlWithRealm, keyId);
+        }
+        return HttpBasicAuthenticationScheme.instance();
     }
 }

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
@@ -1,0 +1,75 @@
+package com.github.scribejava.apis.examples;
+
+import com.github.scribejava.apis.KeycloakApi;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth20Service;
+
+import java.io.IOException;
+import java.security.interfaces.RSAKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Scanner;
+import java.util.concurrent.ExecutionException;
+
+public class KeycloakExampleJWTClientAuth {
+
+    private KeycloakExampleJWTClientAuth() {
+    }
+
+    @SuppressWarnings("PMD.SystemPrintln")
+    public static void main(String... args) throws IOException, InterruptedException, ExecutionException {
+        // Replace these with your own api key, secret, callback, base url and realm
+        final String apiKey = "your_api_key";
+        final String keyId = "your_api_secret";
+        final String callback = "your_callback";
+        final String baseUrl = "your_base_url";
+        final String realm = "your_realm";
+        final RSAPrivateKey privateKey = null; // your private key
+
+        final String protectedResourceUrl = baseUrl + "/auth/realms/" + realm + "/protocol/openid-connect/userinfo";
+
+        final OAuth20Service service = new ServiceBuilder(apiKey)
+                .apiSecret(apiKey)
+                .defaultScope("openid")
+                .callback(callback)
+                .build(KeycloakApi.instance(baseUrl, realm, privateKey, keyId));
+        final Scanner in = new Scanner(System.in);
+
+        System.out.println("=== Keyloack's OAuth Workflow ===");
+        System.out.println();
+
+        // Obtain the Authorization URL
+        System.out.println("Fetching the Authorization URL...");
+        final String authorizationUrl = service.getAuthorizationUrl();
+        System.out.println("Got the Authorization URL!");
+        System.out.println("Now go and authorize ScribeJava here:");
+        System.out.println(authorizationUrl);
+        System.out.println("And paste the authorization code here");
+        System.out.print(">>");
+        final String code = in.nextLine();
+        System.out.println();
+
+        System.out.println("Trading the Authorization Code for an Access Token...");
+        final OAuth2AccessToken accessToken = service.getAccessToken(code);
+        System.out.println("Got the Access Token!");
+        System.out.println("(The raw response looks like this: " + accessToken.getRawResponse() + "')");
+        System.out.println();
+
+        // Now let's go and ask for a protected resource!
+        System.out.println("Now we're going to access a protected resource...");
+        final OAuthRequest request = new OAuthRequest(Verb.GET, protectedResourceUrl);
+        service.signRequest(accessToken, request);
+        try (Response response = service.execute(request)) {
+            System.out.println("Got it! Lets see what we found...");
+            System.out.println();
+            System.out.println(response.getCode());
+            System.out.println(response.getBody());
+        }
+        System.out.println();
+        System.out.println("Thats it man! Go and build something awesome with ScribeJava! :)");
+
+    }
+}

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
@@ -1,18 +1,13 @@
 package com.github.scribejava.apis.examples;
 
+import java.io.IOException;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.concurrent.ExecutionException;
+
 import com.github.scribejava.apis.KeycloakApi;
 import com.github.scribejava.core.builder.ServiceBuilder;
 import com.github.scribejava.core.model.OAuth2AccessToken;
-import com.github.scribejava.core.model.OAuthRequest;
-import com.github.scribejava.core.model.Response;
-import com.github.scribejava.core.model.Verb;
 import com.github.scribejava.core.oauth.OAuth20Service;
-
-import java.io.IOException;
-import java.security.interfaces.RSAKey;
-import java.security.interfaces.RSAPrivateKey;
-import java.util.Scanner;
-import java.util.concurrent.ExecutionException;
 
 public class KeycloakExampleJWTClientAuth {
 
@@ -29,14 +24,11 @@ public class KeycloakExampleJWTClientAuth {
         final String realm = "your_realm";
         final RSAPrivateKey privateKey = null; // your private key
 
-        final String protectedResourceUrl = baseUrl + "/auth/realms/" + realm + "/protocol/openid-connect/userinfo";
-
         final OAuth20Service service = new ServiceBuilder(apiKey)
                 .apiSecret(apiKey)
                 .defaultScope("openid")
                 .callback(callback)
                 .build(KeycloakApi.instance(baseUrl, realm, privateKey, keyId));
-        final Scanner in = new Scanner(System.in);
 
         System.out.println("=== Keyloack's OAuth Workflow ===");
         System.out.println();

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/KeycloakExampleJWTClientAuth.java
@@ -23,7 +23,7 @@ public class KeycloakExampleJWTClientAuth {
     public static void main(String... args) throws IOException, InterruptedException, ExecutionException {
         // Replace these with your own api key, secret, callback, base url and realm
         final String apiKey = "your_api_key";
-        final String keyId = "your_api_secret";
+        final String keyId = "your_public_key_id";
         final String callback = "your_callback";
         final String baseUrl = "your_base_url";
         final String realm = "your_realm";
@@ -43,33 +43,7 @@ public class KeycloakExampleJWTClientAuth {
 
         // Obtain the Authorization URL
         System.out.println("Fetching the Authorization URL...");
-        final String authorizationUrl = service.getAuthorizationUrl();
-        System.out.println("Got the Authorization URL!");
-        System.out.println("Now go and authorize ScribeJava here:");
-        System.out.println(authorizationUrl);
-        System.out.println("And paste the authorization code here");
-        System.out.print(">>");
-        final String code = in.nextLine();
-        System.out.println();
-
-        System.out.println("Trading the Authorization Code for an Access Token...");
-        final OAuth2AccessToken accessToken = service.getAccessToken(code);
-        System.out.println("Got the Access Token!");
-        System.out.println("(The raw response looks like this: " + accessToken.getRawResponse() + "')");
-        System.out.println();
-
-        // Now let's go and ask for a protected resource!
-        System.out.println("Now we're going to access a protected resource...");
-        final OAuthRequest request = new OAuthRequest(Verb.GET, protectedResourceUrl);
-        service.signRequest(accessToken, request);
-        try (Response response = service.execute(request)) {
-            System.out.println("Got it! Lets see what we found...");
-            System.out.println();
-            System.out.println(response.getCode());
-            System.out.println(response.getBody());
-        }
-        System.out.println();
-        System.out.println("Thats it man! Go and build something awesome with ScribeJava! :)");
-
+        final OAuth2AccessToken token = service.getAccessTokenClientCredentialsGrant();
+        System.out.println("Access token: " + token.getAccessToken());
     }
 }

--- a/scribejava-core/pom.xml
+++ b/scribejava-core/pom.xml
@@ -14,6 +14,13 @@
     <name>ScribeJava Core</name>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>3.11.0</version>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConstants.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/model/OAuthConstants.java
@@ -45,6 +45,13 @@ public interface OAuthConstants {
     String RESPONSE_TYPE = "response_type";
     String RESPONSE_TYPE_CODE = "code";
 
+    // https://tools.ietf.org/html/rfc7523#section-2.2
+    String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    String CLIENT_ASSERTION = "client_assertion";
+
+    // https://tools.ietf.org/html/rfc7523#section-8.1
+    String CLIENT_ASSERTION_TYPE_JWT = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
     //not OAuth specific
     String USER_AGENT_HEADER_NAME = "User-Agent";
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationScheme.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationScheme.java
@@ -46,28 +46,27 @@ public class JWTAuthenticationScheme implements ClientAuthentication {
 
   @Override
   public void addClientAuthentication(OAuthRequest request, String apiKey, String apiSecret) {
-    String token = this.createJwtSignedHMAC(apiKey);
+    final String token = this.createJwtSignedHMAC(apiKey);
     request.getBodyParams().add(OAuthConstants.CLIENT_ASSERTION_TYPE, OAuthConstants.CLIENT_ASSERTION_TYPE_JWT);
     request.getBodyParams().add(OAuthConstants.CLIENT_ASSERTION, token);
   }
 
   public String createJwtSignedHMAC(String apiKey) {
-    Algorithm algorithm = Algorithm.RSA256(null, privateKey);
-    Calendar c = Calendar.getInstance();
-    Date now = c.getTime();
+    final Algorithm algorithm = Algorithm.RSA256(null, privateKey);
+    final Calendar c = Calendar.getInstance();
+    final Date now = c.getTime();
     c.add(Calendar.SECOND, 60);
-    Date exp = c.getTime();
+    final Date exp = c.getTime();
 
-    String token = JWT.create()
-                      .withKeyId(keyId)
-                      .withIssuer(apiKey)
-                      .withSubject(apiKey)
-                      .withJWTId(UUID.randomUUID().toString())
-                      .withAudience(this.audience)
-                      .withIssuedAt(now)
-                      .withNotBefore(now)
-                      .withExpiresAt(exp)
-                      .sign(algorithm);
-    return token;
+    return JWT.create()
+    .withKeyId(keyId)
+    .withIssuer(apiKey)
+    .withSubject(apiKey)
+    .withJWTId(UUID.randomUUID().toString())
+    .withAudience(this.audience)
+    .withIssuedAt(now)
+    .withNotBefore(now)
+    .withExpiresAt(exp)
+    .sign(algorithm);
   }
 }

--- a/scribejava-core/src/main/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationScheme.java
+++ b/scribejava-core/src/main/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationScheme.java
@@ -1,0 +1,73 @@
+package com.github.scribejava.core.oauth2.clientauthentication;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.OAuthRequest;
+
+/**
+ * 2.2. Using JWTs for Client Authentication<br>
+ * 3. JWT Format and Processing Requirements<br>
+ * https://tools.ietf.org/html/rfc7523#section-2.2 <br>
+ * JWTs for Client Authentication scheme
+ */
+public class JWTAuthenticationScheme implements ClientAuthentication {
+  private static final ConcurrentMap<String, JWTAuthenticationScheme> INSTANCES = new ConcurrentHashMap<>();
+  private final RSAPrivateKey privateKey;
+  private final String audience;
+  private final String keyId;
+
+  public JWTAuthenticationScheme(RSAPrivateKey privateKey, String audience, String keyId) {
+    this.privateKey = privateKey;
+    this.audience = audience;
+    this.keyId = keyId;
+  }
+
+  public static JWTAuthenticationScheme instance(RSAPrivateKey privateKey, String audience, String keyId) {
+    final String instanceId = audience + keyId;
+
+    JWTAuthenticationScheme scheme = INSTANCES.get(instanceId);
+    if (scheme == null) {
+      scheme = new JWTAuthenticationScheme(privateKey, audience, keyId);
+      final JWTAuthenticationScheme alreadyCreatedScheme = INSTANCES.putIfAbsent(instanceId, scheme);
+      if (alreadyCreatedScheme != null) {
+        return alreadyCreatedScheme;
+      }
+    }
+    return scheme;
+  }
+
+  @Override
+  public void addClientAuthentication(OAuthRequest request, String apiKey, String apiSecret) {
+    String token = this.createJwtSignedHMAC(apiKey);
+    request.getBodyParams().add(OAuthConstants.CLIENT_ASSERTION_TYPE, OAuthConstants.CLIENT_ASSERTION_TYPE_JWT);
+    request.getBodyParams().add(OAuthConstants.CLIENT_ASSERTION, token);
+  }
+
+  public String createJwtSignedHMAC(String apiKey) {
+    Algorithm algorithm = Algorithm.RSA256(null, privateKey);
+    Calendar c = Calendar.getInstance();
+    Date now = c.getTime();
+    c.add(Calendar.SECOND, 60);
+    Date exp = c.getTime();
+
+    String token = JWT.create()
+                      .withKeyId(keyId)
+                      .withIssuer(apiKey)
+                      .withSubject(apiKey)
+                      .withJWTId(UUID.randomUUID().toString())
+                      .withAudience(this.audience)
+                      .withIssuedAt(now)
+                      .withNotBefore(now)
+                      .withExpiresAt(exp)
+                      .sign(algorithm);
+    return token;
+  }
+}

--- a/scribejava-core/src/test/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationSchemeTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationSchemeTest.java
@@ -13,7 +13,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.github.scribejava.core.builder.api.OAuth1SignatureType;
 import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.model.Parameter;
@@ -25,30 +24,32 @@ public class JWTAuthenticationSchemeTest {
 
   @Test
   public void shouldInjectSignedJWT() throws NoSuchAlgorithmException {
-    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
     keyGen.initialize(512);
-    KeyPair keyPair = keyGen.genKeyPair();
-    RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+    final KeyPair keyPair = keyGen.genKeyPair();
+    final RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
     final String audience = "test";
     final String clientId = "test";
     final String keyId = "test";
 
     final JWTAuthenticationScheme scheme = JWTAuthenticationScheme.instance(privateKey, audience, keyId);
 
-    OAuthRequest request = new OAuthRequest(Verb.GET, "https://localhost");
+    final OAuthRequest request = new OAuthRequest(Verb.GET, "https://localhost");
     scheme.addClientAuthentication(request, clientId, clientId);
 
-    assertTrue("Missing or wrong client assertion type", request.getBodyParams().contains(new Parameter(OAuthConstants.CLIENT_ASSERTION_TYPE, OAuthConstants.CLIENT_ASSERTION_TYPE_JWT)));
+    assertTrue("Missing or wrong client assertion type",
+                request.getBodyParams().contains(new Parameter(OAuthConstants.CLIENT_ASSERTION_TYPE,
+                                                                OAuthConstants.CLIENT_ASSERTION_TYPE_JWT)));
     String jwt = null;
-    for(Parameter param : request.getBodyParams().getParams()) {
-      if(param.getKey().equals(OAuthConstants.CLIENT_ASSERTION)) {
+    for (Parameter param : request.getBodyParams().getParams()) {
+      if (param.getKey().equals(OAuthConstants.CLIENT_ASSERTION)) {
         jwt = param.getValue();
       }
     }
 
-    JWTVerifier verified = JWT.require(Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), null))
+    final JWTVerifier verified = JWT.require(Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), null))
             .build();
-    DecodedJWT decoded = verified.verify(jwt);
+    final DecodedJWT decoded = verified.verify(jwt);
     assertTrue("Failed to validate audience", decoded.getAudience().contains(audience));
     assertEquals(clientId, decoded.getSubject());
     assertEquals(clientId, decoded.getIssuer());

--- a/scribejava-core/src/test/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationSchemeTest.java
+++ b/scribejava-core/src/test/java/com/github/scribejava/core/oauth2/clientauthentication/JWTAuthenticationSchemeTest.java
@@ -1,0 +1,58 @@
+package com.github.scribejava.core.oauth2.clientauthentication;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.github.scribejava.core.builder.api.OAuth1SignatureType;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Parameter;
+import com.github.scribejava.core.model.Verb;
+
+import org.junit.Test;
+
+public class JWTAuthenticationSchemeTest {
+
+  @Test
+  public void shouldInjectSignedJWT() throws NoSuchAlgorithmException {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(512);
+    KeyPair keyPair = keyGen.genKeyPair();
+    RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+    final String audience = "test";
+    final String clientId = "test";
+    final String keyId = "test";
+
+    final JWTAuthenticationScheme scheme = JWTAuthenticationScheme.instance(privateKey, audience, keyId);
+
+    OAuthRequest request = new OAuthRequest(Verb.GET, "https://localhost");
+    scheme.addClientAuthentication(request, clientId, clientId);
+
+    assertTrue("Missing or wrong client assertion type", request.getBodyParams().contains(new Parameter(OAuthConstants.CLIENT_ASSERTION_TYPE, OAuthConstants.CLIENT_ASSERTION_TYPE_JWT)));
+    String jwt = null;
+    for(Parameter param : request.getBodyParams().getParams()) {
+      if(param.getKey().equals(OAuthConstants.CLIENT_ASSERTION)) {
+        jwt = param.getValue();
+      }
+    }
+
+    JWTVerifier verified = JWT.require(Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), null))
+            .build();
+    DecodedJWT decoded = verified.verify(jwt);
+    assertTrue("Failed to validate audience", decoded.getAudience().contains(audience));
+    assertEquals(clientId, decoded.getSubject());
+    assertEquals(clientId, decoded.getIssuer());
+    assertEquals(keyId, decoded.getKeyId());
+  }
+
+}


### PR DESCRIPTION
## ☕ Purpose

Add client authentication with RSA256 signed JWT. This flow it part of the [RFC7523](https://tools.ietf.org/html/rfc7523#section-2.2).

My use case for this flow is to get access tokens using client credential without having to use static secrets (client secret).

## 🧐 Checklist

- [x] Unit Test
- [x] Example usage test
- [ ] I did use the auth0 lib to sign the JWT. I saw this project uses not external libs, is this an issue?