### PR TITLE
parameterize MS_LOGIN_URL

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/MicrosoftAzureActiveDirectory20Api.java
@@ -23,6 +23,10 @@ public class MicrosoftAzureActiveDirectory20Api extends BaseMicrosoftAzureActive
         super(tenant);
     }
 
+    protected MicrosoftAzureActiveDirectory20Api(String login_url, String tenant) {
+        super(login_url, tenant);
+    }
+
     private static class InstanceHolder {
 
         private static final MicrosoftAzureActiveDirectory20Api INSTANCE = new MicrosoftAzureActiveDirectory20Api();
@@ -34,6 +38,10 @@ public class MicrosoftAzureActiveDirectory20Api extends BaseMicrosoftAzureActive
 
     public static MicrosoftAzureActiveDirectory20Api custom(String tenant) {
         return new MicrosoftAzureActiveDirectory20Api(tenant);
+    }
+
+    public static MicrosoftAzureActiveDirectory20Api custom(String login_url, String tenant) {
+        return new MicrosoftAzureActiveDirectory20Api(login_url, tenant);
     }
 
     @Override

--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/microsoftazureactivedirectory/BaseMicrosoftAzureActiveDirectoryApi.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/microsoftazureactivedirectory/BaseMicrosoftAzureActiveDirectoryApi.java
@@ -7,9 +7,10 @@ import com.github.scribejava.core.oauth2.clientauthentication.RequestBodyAuthent
 public abstract class BaseMicrosoftAzureActiveDirectoryApi extends DefaultApi20 {
 
     protected static final String COMMON_TENANT = "common";
+    protected static final String COMMON_LOGIN_URL = "https://login.microsoftonline.com/";
 
-    private static final String MSFT_LOGIN_URL = "https://login.microsoftonline.com/";
     private static final String OAUTH_2 = "/oauth2";
+    private final String login_url;
     private final String tenant;
 
     protected BaseMicrosoftAzureActiveDirectoryApi() {
@@ -18,16 +19,22 @@ public abstract class BaseMicrosoftAzureActiveDirectoryApi extends DefaultApi20 
 
     protected BaseMicrosoftAzureActiveDirectoryApi(String tenant) {
         this.tenant = tenant == null || tenant.isEmpty() ? COMMON_TENANT : tenant;
+        this.login_url = COMMON_LOGIN_URL;
+    }
+
+    protected BaseMicrosoftAzureActiveDirectoryApi(String login_url, String tenant) {
+        this(tenant);
+        this.login_url = login_url == null || login_url.isEmpty() ? COMMON_LOGIN_URL : login_url;
     }
 
     @Override
     public String getAccessTokenEndpoint() {
-        return MSFT_LOGIN_URL + tenant + OAUTH_2 + getEndpointVersionPath() + "/token";
+        return login_url + tenant + OAUTH_2 + getEndpointVersionPath() + "/token";
     }
 
     @Override
     protected String getAuthorizationBaseUrl() {
-        return MSFT_LOGIN_URL + tenant + OAUTH_2 + getEndpointVersionPath() + "/authorize";
+        return login_url + tenant + OAUTH_2 + getEndpointVersionPath() + "/authorize";
     }
 
     @Override


### PR DESCRIPTION
Because Azure Active Directory supports four kind of LOGIN_URL (see: [Azure AD authentication endpoints](https://docs.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud#azure-ad-authentication-endpoints)):

- https://login.chinacloudapi.cn/
- https://login.microsoftonline.com/
- https://login.microsoftonline.de/
- https://login.microsoftonline.us/

So, we need to make MS_LOGIN_URL a constructor parameter.