### PR TITLE
Fix sign for OK: decode is not needed and break sign for special cases

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiOAuthService.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiOAuthService.java
@@ -31,7 +31,6 @@ public class OdnoklassnikiOAuthService extends OAuth20Service {
     @Override
     public void signRequest(String accessToken, OAuthRequest request) {
         //sig = lower(md5( sorted_request_params_composed_string + md5(access_token + application_secret_key)))
-        try {
             final String tokenDigest = md5(accessToken + getApiSecret());
 
             final ParameterList queryParams = request.getQueryStringParams();
@@ -47,13 +46,10 @@ public class OdnoklassnikiOAuthService extends OAuth20Service {
                         .append(param.getValue());
             }
 
-            final String sigSource = URLDecoder.decode(stringParams.toString(), "UTF-8") + tokenDigest;
+            final String sigSource = stringParams + tokenDigest;
             request.addQuerystringParameter("sig", md5(sigSource).toLowerCase());
 
             super.signRequest(accessToken, request);
-        } catch (UnsupportedEncodingException unex) {
-            throw new IllegalStateException(unex);
-        }
     }
 
     public static String md5(String orgString) {

--- a/scribejava-apis/src/test/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiServiceTest.java
+++ b/scribejava-apis/src/test/java/com/github/scribejava/apis/odnoklassniki/OdnoklassnikiServiceTest.java
@@ -29,6 +29,16 @@ public class OdnoklassnikiServiceTest {
         final OAuthRequest request = new OAuthRequest(Verb.GET, URL);
         service.signRequest(accessToken, request);
         assertEquals("96127f5ca29a8351399e94bbd284ab16", findParam(request.getQueryStringParams(), "sig"));
+        
+        final OAuthRequest request2 = new OAuthRequest(Verb.GET, URL);
+        request2.addQuerystringParameter("testsimpleparam", "simplevalue");
+        service.signRequest(accessToken, request2);
+        assertEquals("b5355cfc4683869e802747d8aa8acf3f", findParam(request2.getQueryStringParams(), "sig"));
+        
+        final OAuthRequest request3 = new OAuthRequest(Verb.GET, URL);
+        request3.addQuerystringParameter("testsimpleparam", "complex+value%20");
+        service.signRequest(accessToken, request3);
+        assertEquals("229fd8a3fbc42cf545627e6ea719c57d", findParam(request3.getQueryStringParams(), "sig"));
     }
 
     private static String findParam(ParameterList list, String key) {


### PR DESCRIPTION
For an unknown reasons, OK signature was using URL decode while the actual value is already decoded. It leads to the situation when value indeed contains special symbols that can be decoded - signature becomes broken. 

PR fixes this and add few sub test cases to validate that.

P.S. Code was not re-indented after `try` deletion: just to re-highlight actual change. 