### PR TITLE
Adds a decorator for Okhttp requests

### DIFF
--- a/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClient.java
+++ b/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClient.java
@@ -29,6 +29,7 @@ public class OkHttpHttpClient implements HttpClient {
     private static final MediaType DEFAULT_CONTENT_TYPE_MEDIA_TYPE = MediaType.parse(DEFAULT_CONTENT_TYPE);
 
     private final OkHttpClient client;
+    private final OkHttpRequestDecorator decorator;
 
     public OkHttpHttpClient() {
         this(OkHttpHttpClientConfig.defaultConfig());
@@ -36,11 +37,19 @@ public class OkHttpHttpClient implements HttpClient {
 
     public OkHttpHttpClient(OkHttpHttpClientConfig config) {
         final OkHttpClient.Builder clientBuilder = config.getClientBuilder();
-        client = clientBuilder == null ? new OkHttpClient() : clientBuilder.build();
+
+        this.client = clientBuilder == null ? new OkHttpClient() : clientBuilder.build();
+        this.decorator = config.getDecorator();
     }
 
     public OkHttpHttpClient(OkHttpClient client) {
         this.client = client;
+        this.decorator = null;
+    }
+
+    public OkHttpHttpClient(OkHttpClient client, OkHttpRequestDecorator decorator) {
+        this.client = client;
+        this.decorator = decorator;
     }
 
     @Override
@@ -156,6 +165,10 @@ public class OkHttpHttpClient implements HttpClient {
 
         if (userAgent != null) {
             requestBuilder.header(OAuthConstants.USER_AGENT_HEADER_NAME, userAgent);
+        }
+
+        if (decorator != null) {
+            decorator.decorate(requestBuilder);
         }
 
         // create a new call

--- a/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClientConfig.java
+++ b/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpHttpClientConfig.java
@@ -6,6 +6,7 @@ import okhttp3.OkHttpClient;
 public class OkHttpHttpClientConfig implements HttpClientConfig {
 
     private final OkHttpClient.Builder clientBuilder;
+    private OkHttpRequestDecorator decorator;
 
     public OkHttpHttpClientConfig(OkHttpClient.Builder clientBuilder) {
         this.clientBuilder = clientBuilder;
@@ -23,4 +24,19 @@ public class OkHttpHttpClientConfig implements HttpClientConfig {
     public static OkHttpHttpClientConfig defaultConfig() {
         return new OkHttpHttpClientConfig(null);
     }
+
+    public OkHttpRequestDecorator getDecorator() {
+        return decorator;
+    }
+
+    public void setDecorator(OkHttpRequestDecorator decorator) {
+        this.decorator = decorator;
+    }
+
+    public OkHttpHttpClientConfig withDecorator(OkHttpRequestDecorator decorator) {
+        this.decorator = decorator;
+        return this;
+    }
+
+
 }

--- a/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpRequestDecorator.java
+++ b/scribejava-httpclient-okhttp/src/main/java/com/github/scribejava/httpclient/okhttp/OkHttpRequestDecorator.java
@@ -1,0 +1,11 @@
+package com.github.scribejava.httpclient.okhttp;
+
+import okhttp3.Request;
+
+/**
+ * Allows interception of the request building process, e.g. to add custom headers or tags.
+ */
+public interface OkHttpRequestDecorator {
+
+    void decorate(Request.Builder requestBuilder);
+}

--- a/scribejava-httpclient-okhttp/src/test/java/com/github/scribejava/httpclient/okhttp/OkHttpDecoratorTest.java
+++ b/scribejava-httpclient-okhttp/src/test/java/com/github/scribejava/httpclient/okhttp/OkHttpDecoratorTest.java
@@ -1,0 +1,97 @@
+package com.github.scribejava.httpclient.okhttp;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Verb;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request.Builder;
+import okhttp3.ResponseBody;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OkHttpDecoratorTest {
+
+    @Test
+    public void testHttpClient() throws Exception {
+
+        final UUID trackId = UUID.randomUUID();
+
+        final OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(new TrackInterceptor(trackId))
+                .build();
+
+        final OkHttpHttpClient client = new OkHttpHttpClient(httpClient, new TrackDecorator(trackId));
+
+        final Response response = client.execute("", Collections.<String, String>emptyMap(),
+                Verb.GET, "http://dummy/", (byte[]) null);
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void testHttpConfig() throws Exception {
+
+        final UUID trackId = UUID.randomUUID();
+
+        final OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .addInterceptor(new TrackInterceptor(trackId));
+
+        final OkHttpHttpClientConfig config = new OkHttpHttpClientConfig(builder)
+                .withDecorator(new TrackDecorator(trackId));
+
+        final OkHttpHttpClient client = new OkHttpHttpClient(config);
+
+        final Response response = client.execute("", Collections.<String, String>emptyMap(),
+                Verb.GET, "http://dummy/", (byte[]) null);
+
+        assertNotNull(response);
+    }
+
+    public static class TrackInterceptor implements Interceptor {
+
+        private final UUID trackId;
+
+        public TrackInterceptor(UUID trackId) {
+            this.trackId = trackId;
+        }
+
+        @Override
+        public okhttp3.Response intercept(Chain chain) throws IOException {
+            final okhttp3.Request request = chain.request();
+
+            final UUID value = request.tag(UUID.class);
+
+            assertNotNull(value);
+            assertEquals(trackId, value);
+
+            return new okhttp3.Response.Builder()
+                    .code(200)
+                    .message("OK")
+                    .body(ResponseBody.create("Nothing here", MediaType.parse("text/plain")))
+                    .protocol(Protocol.HTTP_1_1)
+                    .request(request).build();
+        }
+    }
+
+    public static class TrackDecorator implements OkHttpRequestDecorator {
+
+        private final UUID uuid;
+
+        public TrackDecorator(UUID uuid) {
+            this.uuid = uuid;
+        }
+
+        @Override
+        public void decorate(Builder requestBuilder) {
+            requestBuilder.tag(UUID.class, uuid);
+        }
+    }
+}


### PR DESCRIPTION
This allows customization of all requests generated by the library
through OkHttp, e.g. for tracking or adding custom headers.