### PR TITLE
SlackJsonTokenExtractor handle null access_token

### DIFF
--- a/scribejava-apis/src/main/java/com/github/scribejava/apis/slack/SlackJsonTokenExtractor.java
+++ b/scribejava-apis/src/main/java/com/github/scribejava/apis/slack/SlackJsonTokenExtractor.java
@@ -2,6 +2,12 @@ package com.github.scribejava.apis.slack;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.utils.Preconditions;
+
+import java.io.IOException;
 
 public class SlackJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor {
 
@@ -15,6 +21,37 @@ public class SlackJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor {
 
     public static SlackJsonTokenExtractor instance() {
         return SlackJsonTokenExtractor.InstanceHolder.INSTANCE;
+    }
+
+    @Override
+    public OAuth2AccessToken extract(Response response) throws IOException {
+        final String body = response.getBody();
+        Preconditions.checkEmptyString(body,
+                "Response body is incorrect. Can't extract a token from an empty string");
+
+        if (response.getCode() != 200) {
+            generateError(response);
+        }
+        return createToken(body);
+    }
+
+    // Overridden private method
+    private OAuth2AccessToken createToken(String rawResponse) throws IOException {
+
+        final JsonNode response = OBJECT_MAPPER.readTree(rawResponse);
+
+        final JsonNode expiresInNode = response.get("expires_in");
+        final JsonNode refreshToken = response.get(OAuthConstants.REFRESH_TOKEN);
+        final JsonNode scope = response.get(OAuthConstants.SCOPE);
+        final JsonNode tokenType = response.get("token_type");
+        final JsonNode globalAccessToken = response.get(OAuthConstants.ACCESS_TOKEN);
+
+        return createToken( //
+                globalAccessToken == null ? "" : globalAccessToken.asText(), // Avoid "access_token can't be null"
+                tokenType == null ? null : tokenType.asText(),
+                expiresInNode == null ? null : expiresInNode.asInt(),
+                refreshToken == null ? null : refreshToken.asText(),
+                scope == null ? null : scope.asText(), response, rawResponse);
     }
 
     @Override


### PR DESCRIPTION
Issue: https://github.com/scribejava/scribejava/issues/1023
Slack does not always provide the bot access token, if you don't ask for those scopes.
Example:
- Requesting: slack oauth `&scope=&user_scope=users.profile%3Aread`
- Response
```json
{"ok":true,"app_id":"AA","authed_user":{"id":"UID","scope":"channels:read,groups:read,users.profile:read,files:write:user","access_token":"xoxp-1234-etc","token_type":"user"},"team":{"id":"TId","name":"TeamName"},"enterprise":{"id":"EId","name":"EName"},"is_enterprise_install":false}
```

Error - This leads to:
```
com.github.scribejava.core.exceptions.OAuthException: Response body is incorrect. Can't extract a 'access_token' from this: '{"ok":true,"app_id":"AA",... <as above>'
```

### Solution:
Downgrade "access_token" to not be extractRequiredParameter, by overriding the implementation.
https://github.com/scribejava/scribejava/blob/9c8e4c12df64fc15a9d7fb0335156e918977a39a/scribejava-core/src/main/java/com/github/scribejava/core/extractors/OAuth2AccessTokenJsonExtractor.java#L90