### PR TITLE
[readme] Change variable naming in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 Who said OAuth/OAuth2 was difficult? Configuring ScribeJava is __so easy your grandma can do it__! check it out:
 
 ```java
-OAuthService service = new ServiceBuilder(YOUR_API_KEY)
-                                  .apiSecret(YOUR_API_SECRET)
+OAuthService service = new ServiceBuilder(YOUR_CLIENT_ID)
+                                  .apiSecret(YOUR_CLIENT_SECRET)
                                   .build(LinkedInApi20.instance());
 ```
 


### PR DESCRIPTION
This is a more common convention, which is also used in your own examples: https://github.com/scribejava/scribejava/blob/master/scribejava-apis/src/test/java/com/github/scribejava/apis/examples/Google20Example.java#L27-L35